### PR TITLE
Feat: 이메일 인증번호 발송 및 확인 구현 (#12)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-mail' // 이메일 전송
 
 	// QueryDSL
 	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"

--- a/src/main/java/com/umc/banddy/domain/member/Member.java
+++ b/src/main/java/com/umc/banddy/domain/member/Member.java
@@ -1,15 +1,16 @@
 package com.umc.banddy.domain.member;
 
+import com.umc.banddy.domain.member.enums.Gender;
+import com.umc.banddy.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import com.umc.banddy.domain.member.enums.Gender;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -35,7 +36,7 @@ public class Member {
     private String region;  // 시
 
     @Column(length = 20)
-    private String district; //구
+    private String district; // 구
 
     @Column(length = 500)
     private String refreshToken;
@@ -43,5 +44,4 @@ public class Member {
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
-
 }

--- a/src/main/java/com/umc/banddy/domain/member/controller/EmailVerificationController.java
+++ b/src/main/java/com/umc/banddy/domain/member/controller/EmailVerificationController.java
@@ -1,0 +1,29 @@
+package com.umc.banddy.domain.member.controller;
+
+import com.umc.banddy.domain.member.dto.EmailSendRequest;
+import com.umc.banddy.domain.member.dto.EmailVerifyRequest;
+import com.umc.banddy.domain.member.dto.EmailVerifyResponse;
+import com.umc.banddy.domain.member.service.EmailVerificationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/members/email")
+@RequiredArgsConstructor
+public class EmailVerificationController {
+
+    private final EmailVerificationService emailVerificationService;
+
+    @PostMapping("/send-code")
+    public ResponseEntity<String> sendCode(@RequestBody @Valid EmailSendRequest request) {
+        emailVerificationService.sendCode(request);
+        return ResponseEntity.ok("인증번호가 전송되었습니다.");
+    }
+
+    @PostMapping("/verify-code")
+    public ResponseEntity<EmailVerifyResponse> verifyCode(@RequestBody @Valid EmailVerifyRequest request) {
+        return ResponseEntity.ok(emailVerificationService.verifyCode(request));
+    }
+}

--- a/src/main/java/com/umc/banddy/domain/member/controller/EmailVerificationController.java
+++ b/src/main/java/com/umc/banddy/domain/member/controller/EmailVerificationController.java
@@ -4,25 +4,36 @@ import com.umc.banddy.domain.member.dto.EmailSendRequest;
 import com.umc.banddy.domain.member.dto.EmailVerifyRequest;
 import com.umc.banddy.domain.member.dto.EmailVerifyResponse;
 import com.umc.banddy.domain.member.service.EmailVerificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "email-verification", description = "이메일 인증번호 전송 및 확인 API")
 @RestController
-@RequestMapping("/members/email")
+@RequestMapping("/auth")
 @RequiredArgsConstructor
 public class EmailVerificationController {
 
     private final EmailVerificationService emailVerificationService;
 
-    @PostMapping("/send-code")
+    @Operation(
+            summary = "이메일 인증번호 전송",
+            description = "사용자의 이메일로 인증번호를 전송합니다. 인증번호는 5분간 유효합니다."
+    )
+    @PostMapping("/send")
     public ResponseEntity<String> sendCode(@RequestBody @Valid EmailSendRequest request) {
         emailVerificationService.sendCode(request);
-        return ResponseEntity.ok("인증번호가 전송되었습니다.");
+        return ResponseEntity.ok("인증번호가 발송되었습니다.");
     }
 
-    @PostMapping("/verify-code")
+    @Operation(
+            summary = "이메일 인증번호 확인"
+    )
+    @PostMapping("/verify")
     public ResponseEntity<EmailVerifyResponse> verifyCode(@RequestBody @Valid EmailVerifyRequest request) {
         return ResponseEntity.ok(emailVerificationService.verifyCode(request));
     }

--- a/src/main/java/com/umc/banddy/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/banddy/domain/member/controller/MemberController.java
@@ -18,7 +18,7 @@ import java.util.HashMap;
 
 @Tag(name = "member", description = "회원 관련 API")
 @RestController
-@RequestMapping("/members")
+@RequestMapping("/member")
 @RequiredArgsConstructor
 public class MemberController {
 
@@ -26,7 +26,7 @@ public class MemberController {
     private final MemberLoginService memberLoginService;
 
     @Operation(summary = "회원가입", description = "회원가입 api")
-    @PostMapping("/join")
+    @PostMapping
     public ResponseEntity<Map<String, String>> signup(@RequestBody @Valid SignupRequest request) {
         memberCommandService.signup(request);
         Map<String, String> response = new HashMap<>();

--- a/src/main/java/com/umc/banddy/domain/member/dto/EmailSendRequest.java
+++ b/src/main/java/com/umc/banddy/domain/member/dto/EmailSendRequest.java
@@ -1,0 +1,12 @@
+package com.umc.banddy.domain.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class EmailSendRequest {
+    @NotBlank
+    @Email
+    private String email;
+}

--- a/src/main/java/com/umc/banddy/domain/member/dto/EmailVerifyRequest.java
+++ b/src/main/java/com/umc/banddy/domain/member/dto/EmailVerifyRequest.java
@@ -1,0 +1,13 @@
+package com.umc.banddy.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class EmailVerifyRequest {
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String code;
+}

--- a/src/main/java/com/umc/banddy/domain/member/dto/EmailVerifyRequest.java
+++ b/src/main/java/com/umc/banddy/domain/member/dto/EmailVerifyRequest.java
@@ -5,8 +5,6 @@ import lombok.Getter;
 
 @Getter
 public class EmailVerifyRequest {
-    @NotBlank
-    private String email;
 
     @NotBlank
     private String code;

--- a/src/main/java/com/umc/banddy/domain/member/dto/EmailVerifyResponse.java
+++ b/src/main/java/com/umc/banddy/domain/member/dto/EmailVerifyResponse.java
@@ -1,0 +1,11 @@
+package com.umc.banddy.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class EmailVerifyResponse {
+    private boolean verified;
+    private String message;
+}

--- a/src/main/java/com/umc/banddy/domain/member/service/EmailVerificationService.java
+++ b/src/main/java/com/umc/banddy/domain/member/service/EmailVerificationService.java
@@ -8,9 +8,10 @@ import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 @RequiredArgsConstructor
@@ -18,30 +19,60 @@ public class EmailVerificationService {
 
     private final JavaMailSender mailSender;
 
-    private final Map<String, String> verificationStore = new HashMap<>();
+    // 기존 Map<String, String> → 인증번호 + 생성시간 저장용 객체로 변경
+    private final Map<String, VerificationData> verificationStore = new ConcurrentHashMap<>();
 
     public void sendCode(EmailSendRequest request) {
         String code = generateCode();
-        verificationStore.put(request.getEmail(), code);
+
+        // key = code (이메일 없이 인증번호로만 저장) 기존 코드에서 변경..
+        verificationStore.put(code, new VerificationData(code));
 
         SimpleMailMessage message = new SimpleMailMessage();
         message.setTo(request.getEmail());
-        message.setSubject("[Banddy] 이메일 인증번호");
-        message.setText("인증번호는 [" + code + "] 입니다.\n5분 이내에 입력해주세요.");
+        message.setSubject("[Banddy] 회원가입 인증번호입니다.");
+        message.setText(
+                "안녕하세요, 밴디입니다.\n" +
+                        "요청하신 이메일 인증을 위해 아래 인증번호를 입력해 주세요.\n" +
+                        "인증번호: " + code + "\n" +
+                        "이 인증번호는 5분간 유효합니다.\n" +
+                        "감사합니다."
+        );
 
         mailSender.send(message);
     }
 
     public EmailVerifyResponse verifyCode(EmailVerifyRequest request) {
-        String storedCode = verificationStore.get(request.getEmail());
-        if (storedCode != null && storedCode.equals(request.getCode())) {
-            verificationStore.remove(request.getEmail()); // 인증 성공 시 삭제
-            return new EmailVerifyResponse(true, "인증이 완료되었습니다.");
+        // 이메일이 아닌 인증번호로 찾음
+        VerificationData data = verificationStore.get(request.getCode());
+
+        if (data == null || data.isExpired()) {
+            return new EmailVerifyResponse(false, "인증번호가 만료되었거나 존재하지 않습니다.");
         }
-        return new EmailVerifyResponse(false, "인증번호가 일치하지 않습니다.");
+
+        verificationStore.remove(request.getCode()); // 인증 성공 시 제거
+        return new EmailVerifyResponse(true, "인증이 완료되었습니다.");
     }
 
     private String generateCode() {
-        return String.valueOf(new Random().nextInt(900000) + 100000);
+        return String.valueOf(new Random().nextInt(90000) + 10000);
+    }
+
+    private static class VerificationData {
+        private final String code;
+        private final LocalDateTime createdAt;
+
+        public VerificationData(String code) {
+            this.code = code;
+            this.createdAt = LocalDateTime.now();
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public boolean isExpired() {
+            return createdAt.plusMinutes(5).isBefore(LocalDateTime.now());
+        }
     }
 }

--- a/src/main/java/com/umc/banddy/domain/member/service/EmailVerificationService.java
+++ b/src/main/java/com/umc/banddy/domain/member/service/EmailVerificationService.java
@@ -1,0 +1,47 @@
+package com.umc.banddy.domain.member.service;
+
+import com.umc.banddy.domain.member.dto.EmailSendRequest;
+import com.umc.banddy.domain.member.dto.EmailVerifyRequest;
+import com.umc.banddy.domain.member.dto.EmailVerifyResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationService {
+
+    private final JavaMailSender mailSender;
+
+    private final Map<String, String> verificationStore = new HashMap<>();
+
+    public void sendCode(EmailSendRequest request) {
+        String code = generateCode();
+        verificationStore.put(request.getEmail(), code);
+
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(request.getEmail());
+        message.setSubject("[Banddy] 이메일 인증번호");
+        message.setText("인증번호는 [" + code + "] 입니다.\n5분 이내에 입력해주세요.");
+
+        mailSender.send(message);
+    }
+
+    public EmailVerifyResponse verifyCode(EmailVerifyRequest request) {
+        String storedCode = verificationStore.get(request.getEmail());
+        if (storedCode != null && storedCode.equals(request.getCode())) {
+            verificationStore.remove(request.getEmail()); // 인증 성공 시 삭제
+            return new EmailVerifyResponse(true, "인증이 완료되었습니다.");
+        }
+        return new EmailVerifyResponse(false, "인증번호가 일치하지 않습니다.");
+    }
+
+    private String generateCode() {
+        return String.valueOf(new Random().nextInt(900000) + 100000);
+    }
+}

--- a/src/main/java/com/umc/banddy/domain/member/service/MemberLoginService.java
+++ b/src/main/java/com/umc/banddy/domain/member/service/MemberLoginService.java
@@ -23,7 +23,7 @@ public class MemberLoginService {
 
     public LoginResponse login(LoginRequest request) {
         Member member = memberRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.AUTHENTICATION_FAILED));
 
         if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
             throw new GeneralException(ErrorStatus.AUTHENTICATION_FAILED);

--- a/src/main/java/com/umc/banddy/domain/member/service/MemberLoginService.java
+++ b/src/main/java/com/umc/banddy/domain/member/service/MemberLoginService.java
@@ -6,9 +6,8 @@ import com.umc.banddy.domain.member.MemberRepository;
 import com.umc.banddy.domain.member.dto.LoginRequest;
 import com.umc.banddy.domain.member.dto.LoginResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.User;
+import com.umc.banddy.global.apiPayload.code.status.ErrorStatus;
+import com.umc.banddy.global.apiPayload.exception.GeneralException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -24,10 +23,10 @@ public class MemberLoginService {
 
     public LoginResponse login(LoginRequest request) {
         Member member = memberRepository.findByEmail(request.getEmail())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         if (!passwordEncoder.matches(request.getPassword(), member.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new GeneralException(ErrorStatus.AUTHENTICATION_FAILED);
         }
 
         String accessToken = jwtTokenUtil.generateAccessToken(member);
@@ -38,5 +37,4 @@ public class MemberLoginService {
 
         return new LoginResponse(member.getId(), accessToken, refreshToken);
     }
-
 }

--- a/src/main/java/com/umc/banddy/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/banddy/global/apiPayload/code/status/ErrorStatus.java
@@ -41,7 +41,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER4002", "이미 존재하는 이메일입니다."),
 
     // 인증 관련 에러
-    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH4001", "이메일 또는 비밀번호가 일치하지 않습니다."),
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH4001", "아이디 또는 비밀번호가 일치하지 않습니다."),
     DYNAMIC_KEY_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH4003", "사용자에 대한 동적 키가 존재하지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4011", "유효하지 않은 토큰입니다."),
     TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH4012", "토큰이 만료되었습니다."),

--- a/src/main/java/com/umc/banddy/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/banddy/global/apiPayload/code/status/ErrorStatus.java
@@ -29,8 +29,16 @@ public enum ErrorStatus implements BaseErrorCode {
 
 
     // Member
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4004", "회원 정보를 찾을 수 없습니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4004", "회원 정보를 찾을 수 없습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MEMBER4002", "이미 존재하는 이메일입니다."),
 
+    // 인증 관련 에러
+    AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "AUTH4001", "이메일 또는 비밀번호가 일치하지 않습니다."),
+    DYNAMIC_KEY_NOT_FOUND(HttpStatus.BAD_REQUEST, "AUTH4003", "사용자에 대한 동적 키가 존재하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4011", "유효하지 않은 토큰입니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH4012", "토큰이 만료되었습니다."),
+    VERIFICATION_CODE_WRONG(HttpStatus.BAD_REQUEST, "AUTH4021", "인증번호가 일치하지 않습니다."),
+    VERIFICATION_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "AUTH4022", "인증번호가 만료되었습니다.");
 
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,8 +29,8 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: kssjshyjj@gmail.com
-    password: vdhe bosw ymui ohab
+    username: banddy79@gmail.com
+    password: ${MAIL_PASSWORD}
     properties:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,14 @@ spring:
         hbm2ddl:
           auto: update
         default_batch_fetch_size: 1000
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: kssjshyjj@gmail.com
+    password: vdhe bosw ymui ohab
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
 
 spotify:
   client-id: ${SPOTIFY_CLIENT_ID}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- #12 


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- BaseEntity 상속 추가
- yml에 Gmail SMTP 설정 추가
- 이메일 인증번호 전송 구현
- 이메일 인증번호 확인 구현 
- 인증번호 중복 방지를 위해 인증번호 자체를 key로 저장 (이메일까지 확인에 필요 x)

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- .env 노션에 추가해뒀습니다! 
