### PR TITLE
Feat: 로그아웃 및 회원탈퇴 구현 (#18) 

### DIFF
--- a/src/main/java/com/umc/banddy/domain/auth/service/AuthService.java
+++ b/src/main/java/com/umc/banddy/domain/auth/service/AuthService.java
@@ -4,11 +4,14 @@ import com.umc.banddy.domain.auth.service.TokenBlacklistService;
 import com.umc.banddy.domain.member.domain.Member;
 import com.umc.banddy.domain.member.repository.MemberRepository;
 import com.umc.banddy.global.apiPayload.code.status.ErrorStatus;
+import com.umc.banddy.domain.member.enums.Status;
 import com.umc.banddy.global.apiPayload.exception.handler.AuthHandler;
 import com.umc.banddy.global.security.jwt.JwtTokenUtil;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import com.umc.banddy.domain.member.enums.Status;
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -57,5 +60,13 @@ public class AuthService {
         return jwtTokenUtil.generateAccessToken(member);
     }
 
+    @Transactional
+    public void deactivateMember(Long memberId, String refreshToken) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new AuthHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        member.deactivate(); // status → INACTIVE, inactiveDate → now()
+        tokenBlacklistService.addToBlackList(refreshToken);
+    }
 }
 

--- a/src/main/java/com/umc/banddy/domain/auth/web/controller/AuthController.java
+++ b/src/main/java/com/umc/banddy/domain/auth/web/controller/AuthController.java
@@ -2,7 +2,9 @@ package com.umc.banddy.domain.auth.web.controller;
 
 import com.umc.banddy.domain.auth.service.AuthService;
 import com.umc.banddy.domain.auth.web.dto.LogoutRequest;
+import com.umc.banddy.domain.auth.web.dto.DeactivateRequest;
 import com.umc.banddy.domain.auth.web.dto.RefreshTokenRequest;
+import com.umc.banddy.global.apiPayload.ApiResponse;
 import com.umc.banddy.global.security.jwt.JwtTokenUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -53,5 +55,9 @@ public class AuthController {
         response.put("accessToken", newAccessToken);
         return ResponseEntity.ok(response);
     }
-
+    @PostMapping("/inactive")
+    public ApiResponse<String> deactivate(@RequestBody DeactivateRequest request) {
+        authService.deactivateMember(request.getMemberId(), request.getRefreshToken());
+        return ApiResponse.onSuccess("회원 탈퇴가 완료되었습니다.");
+    }
 }

--- a/src/main/java/com/umc/banddy/domain/auth/web/dto/DeactivateRequest.java
+++ b/src/main/java/com/umc/banddy/domain/auth/web/dto/DeactivateRequest.java
@@ -1,0 +1,9 @@
+package com.umc.banddy.domain.auth.web.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DeactivateRequest {
+    private Long memberId;
+    private String refreshToken;
+}

--- a/src/main/java/com/umc/banddy/domain/member/domain/Member.java
+++ b/src/main/java/com/umc/banddy/domain/member/domain/Member.java
@@ -1,7 +1,12 @@
 package com.umc.banddy.domain.member.domain;
 
 import com.umc.banddy.domain.member.enums.Gender;
+import com.umc.banddy.domain.member.enums.Status;
+import com.umc.banddy.domain.member.enums.Role;
+import com.umc.banddy.domain.member.listener.MemberEntityListener;
 import com.umc.banddy.global.entity.BaseEntity;
+
+import java.time.LocalDate;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,6 +15,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@EntityListeners(MemberEntityListener.class)
 public class Member extends BaseEntity {
 
     @Id
@@ -50,14 +56,29 @@ public class Member extends BaseEntity {
     @Column(nullable = true)
     private String mediaUrl;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Role role;
+
+
+    private LocalDate inactiveDate;
+
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
 
-    public void updateProfile(String profileImageUrl, String introduction, String mediaUrl) {
+    public void updateProfile(String profileImageUrl, String bio, String mediaUrl) {
         if (profileImageUrl != null) this.profileImageUrl = profileImageUrl;
-        if (bio != null) this.bio = bio;
+        if (this.bio != null) this.bio = this.bio;
         if (mediaUrl != null) this.mediaUrl = mediaUrl;
     }
 
+    public void deactivate() {
+        this.status = Status.INACTIVE;
+        this.inactiveDate = LocalDate.now();
+    }
 }

--- a/src/main/java/com/umc/banddy/domain/member/enums/Role.java
+++ b/src/main/java/com/umc/banddy/domain/member/enums/Role.java
@@ -1,0 +1,6 @@
+package com.umc.banddy.domain.member.enums;
+
+public enum Role {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/umc/banddy/domain/member/enums/Status.java
+++ b/src/main/java/com/umc/banddy/domain/member/enums/Status.java
@@ -1,0 +1,5 @@
+package com.umc.banddy.domain.member.enums;
+
+public enum Status {
+    ACTIVE, INACTIVE
+}

--- a/src/main/java/com/umc/banddy/domain/member/listener/MemberEntityListener.java
+++ b/src/main/java/com/umc/banddy/domain/member/listener/MemberEntityListener.java
@@ -1,0 +1,15 @@
+package com.umc.banddy.domain.member.listener;
+
+import com.umc.banddy.domain.member.domain.Member;
+import com.umc.banddy.domain.member.enums.Status;
+import jakarta.persistence.PostLoad;
+
+public class MemberEntityListener {
+
+    @PostLoad
+    public void onPostLoad(Member member) {
+        if (member.getStatus() == Status.INACTIVE) {
+            throw new IllegalStateException("탈퇴한 회원입니다. 접근 불가.");
+        }
+    }
+}

--- a/src/main/java/com/umc/banddy/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/banddy/domain/member/repository/MemberRepository.java
@@ -1,8 +1,11 @@
 package com.umc.banddy.domain.member.repository;
 
 import com.umc.banddy.domain.member.domain.Member;
+import com.umc.banddy.domain.member.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -10,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
     // 닉네임 중복 확인
     boolean existsByNickname(String nickname);
+    List<Member> findByStatusAndInactiveDateBefore(Status status, LocalDate date);
+
 }

--- a/src/main/java/com/umc/banddy/domain/member/service/CustomUserDetailsService.java
+++ b/src/main/java/com/umc/banddy/domain/member/service/CustomUserDetailsService.java
@@ -1,0 +1,35 @@
+package com.umc.banddy.domain.member.service;
+
+import com.umc.banddy.domain.member.domain.Member;
+import com.umc.banddy.domain.member.enums.Status;
+import com.umc.banddy.domain.member.enums.Role;
+import com.umc.banddy.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        if (member.getStatus() == Status.INACTIVE) {
+            throw new IllegalStateException("탈퇴한 회원입니다.");
+        }
+
+        return User.builder()
+                .username(member.getEmail())
+                .password(member.getPassword())
+                .roles(member.getRole().name())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/banddy/domain/member/service/MemberCommandService.java
+++ b/src/main/java/com/umc/banddy/domain/member/service/MemberCommandService.java
@@ -3,10 +3,15 @@ package com.umc.banddy.domain.member.service;
 import com.umc.banddy.domain.member.domain.Member;
 import com.umc.banddy.domain.member.repository.MemberRepository;
 import com.umc.banddy.domain.member.web.dto.SignupRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
 import com.umc.banddy.domain.member.web.dto.NicknameCheckResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import java.time.LocalDate;
+import java.util.List;
+import com.umc.banddy.domain.member.enums.Status;
 
 @Service
 @RequiredArgsConstructor
@@ -39,5 +44,12 @@ public class MemberCommandService {
         } else {
             return new NicknameCheckResponse(true, "사용 가능한 닉네임입니다.");
         }
+    }
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정
+    @Transactional
+    public void deleteInactiveMembers() {
+        LocalDate sevenDaysAgo = LocalDate.now().minusDays(7);
+        List<Member> membersToDelete = memberRepository.findByStatusAndInactiveDateBefore(Status.INACTIVE, sevenDaysAgo);
+        memberRepository.deleteAll(membersToDelete);
     }
 }

--- a/src/main/java/com/umc/banddy/domain/member/service/MemberSurveyServiceImpl.java
+++ b/src/main/java/com/umc/banddy/domain/member/service/MemberSurveyServiceImpl.java
@@ -46,7 +46,7 @@ public class MemberSurveyServiceImpl implements MemberSurveyService {
                 .orElseThrow(() -> new IllegalArgumentException("회원 정보를 찾을 수 없습니다."));
 
         // 프로필 정보 업데이트
-        member.updateProfile(request.getProfileImageUrl(), request.getIntroduction(), request.getMediaUrl());
+        member.updateProfile(request.getProfileImageUrl(), request.getBio(), request.getMediaUrl());
 
         // 장르 저장
         request.getGenreNames().forEach(name ->

--- a/src/main/java/com/umc/banddy/domain/member/web/dto/MemberSurveyRequest.java
+++ b/src/main/java/com/umc/banddy/domain/member/web/dto/MemberSurveyRequest.java
@@ -20,7 +20,7 @@ public class MemberSurveyRequest {
     private List<SnsLinkRequest> snsLinks;
 
     private String profileImageUrl;
-    private String introduction;
+    private String bio;
     private String mediaUrl;
 
     @Getter

--- a/src/main/java/com/umc/banddy/global/config/SchedulerConfig.java
+++ b/src/main/java/com/umc/banddy/global/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.umc.banddy.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- #18 


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
로그아웃 구현 
- TokenBlacklist 엔티티 생성 -> 로그아웃 시 refreshToken 저장

회원 탈퇴 구현 
- memberInfo의 status를 inactive로 변경
- 블랙리스트에 refreshToken 저장
- 7일 후 inactive 회원 정보 삭제 

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- 
