### PR TITLE
Feat: 비슷한 유저가 많이 저장한 곡/아티스트 조회 기능 구현 (#47)

### DIFF
--- a/src/main/java/com/umc/banddy/domain/music/artist/repository/MemberArtistRepository.java
+++ b/src/main/java/com/umc/banddy/domain/music/artist/repository/MemberArtistRepository.java
@@ -3,7 +3,10 @@ package com.umc.banddy.domain.music.artist.repository;
 import com.umc.banddy.domain.member.domain.Member;
 import com.umc.banddy.domain.music.artist.domain.Artist;
 import com.umc.banddy.domain.music.artist.domain.MemberArtist;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,5 +15,16 @@ public interface MemberArtistRepository extends JpaRepository<MemberArtist, Long
     Optional<MemberArtist> findByMemberAndArtist(Member member, Artist artist);
     List<MemberArtist> findAllByMember(Member member);
     void deleteByMemberAndArtist(Member member, Artist artist);
+
     List<MemberArtist> findByMemberId(Long memberId);
+
+    @Query("SELECT ma.artist FROM MemberArtist ma " +
+            "WHERE ma.member IN :members " +
+            "GROUP BY ma.artist " +
+            "ORDER BY COUNT(ma.artist) DESC")
+    List<Artist> findTopSavedArtistsByMembers(@Param("members") List<Member> members, Pageable pageable);
+
+    default List<Artist> findTopSavedArtistsByMembers(List<Member> members, int limit) {
+        return findTopSavedArtistsByMembers(members, Pageable.ofSize(limit));
+    }
 }

--- a/src/main/java/com/umc/banddy/domain/music/track/repository/MemberTrackRepository.java
+++ b/src/main/java/com/umc/banddy/domain/music/track/repository/MemberTrackRepository.java
@@ -3,14 +3,32 @@ package com.umc.banddy.domain.music.track.repository;
 import com.umc.banddy.domain.member.domain.Member;
 import com.umc.banddy.domain.music.track.domain.Track;
 import com.umc.banddy.domain.music.track.domain.mapping.MemberTrack;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface MemberTrackRepository extends JpaRepository<MemberTrack, Long> {
+
     Optional<MemberTrack> findByMemberAndTrack(Member member, Track track);
+
     void deleteByMemberAndTrack(Member member, Track track);
+
     List<MemberTrack> findAllByMember(Member member);
+
     List<MemberTrack> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+
+    // 비슷한 유저들의 인기 트랙 조회
+    @Query("SELECT mt.track FROM MemberTrack mt " +
+            "WHERE mt.member IN :members " +
+            "GROUP BY mt.track " +
+            "ORDER BY COUNT(mt.track) DESC")
+    List<Track> findTopSavedTracksByMembers(@Param("members") List<Member> members, Pageable pageable);
+
+    default List<Track> findTopSavedTracksByMembers(List<Member> members, int limit) {
+        return findTopSavedTracksByMembers(members, Pageable.ofSize(limit));
+    }
 }

--- a/src/main/java/com/umc/banddy/domain/mypage/similarartist/converter/SimilarArtistConverter.java
+++ b/src/main/java/com/umc/banddy/domain/mypage/similarartist/converter/SimilarArtistConverter.java
@@ -1,0 +1,16 @@
+package com.umc.banddy.domain.mypage.similarartist.converter;
+
+import com.umc.banddy.domain.music.artist.domain.Artist;
+import com.umc.banddy.domain.mypage.similarartist.web.dto.SimilarArtistResponse;
+
+public class SimilarArtistConverter {
+
+    public static SimilarArtistResponse toResponse(Artist artist) {
+        return SimilarArtistResponse.builder()
+                .artistId(artist.getId())
+                .name(artist.getName())
+                .imageUrl(artist.getImageUrl())
+                .build();
+    }
+}
+

--- a/src/main/java/com/umc/banddy/domain/mypage/similarartist/service/SimilarArtistService.java
+++ b/src/main/java/com/umc/banddy/domain/mypage/similarartist/service/SimilarArtistService.java
@@ -1,0 +1,38 @@
+package com.umc.banddy.domain.mypage.similarartist.service;
+
+import com.umc.banddy.domain.member.domain.Member;
+import com.umc.banddy.domain.member.repository.MemberRepository;
+import com.umc.banddy.domain.music.artist.domain.Artist;
+import com.umc.banddy.domain.music.artist.repository.MemberArtistRepository;
+import com.umc.banddy.domain.mypage.similarartist.converter.SimilarArtistConverter;
+import com.umc.banddy.domain.mypage.similarartist.web.dto.SimilarArtistResponse;
+import com.umc.banddy.global.util.MemberSimilarityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SimilarArtistService {
+
+    private final MemberRepository memberRepository;
+    private final MemberArtistRepository memberArtistRepository;
+    private final MemberSimilarityUtil similarityUtil;
+
+    public List<SimilarArtistResponse> getArtistsSavedBySimilarUsers(Long loginMemberId) {
+        Member loginMember = memberRepository.findById(loginMemberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        // 유사한 유저들 추출
+        List<Member> similarMembers = similarityUtil.findSimilarMembers(loginMember);
+
+        // 유사한 유저들이 저장한 아티스트 인기순 정렬 후 상위 5개 추출
+        List<Artist> artists = memberArtistRepository.findTopSavedArtistsByMembers(similarMembers, 5);
+
+        return artists.stream()
+                .map(SimilarArtistConverter::toResponse)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/umc/banddy/domain/mypage/similarartist/web/controller/SimilarArtistController.java
+++ b/src/main/java/com/umc/banddy/domain/mypage/similarartist/web/controller/SimilarArtistController.java
@@ -1,0 +1,39 @@
+package com.umc.banddy.domain.mypage.similarartist.web.controller;
+
+import com.umc.banddy.domain.mypage.similarartist.service.SimilarArtistService;
+import com.umc.banddy.domain.mypage.similarartist.web.dto.SimilarArtistResponse;
+import com.umc.banddy.global.security.jwt.JwtTokenUtil;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/artists")
+@RequiredArgsConstructor
+@Tag(name = "비슷한 유저 아티스트 추천")
+public class SimilarArtistController {
+
+    private final SimilarArtistService similarArtistService;
+    private final JwtTokenUtil jwtTokenUtil;
+
+    @GetMapping("/similar")
+    public ResponseEntity<List<SimilarArtistResponse>> getSimilarArtists(HttpServletRequest request) {
+        String token = JwtTokenUtil.extractToken(request);
+        if (token == null || token.isBlank()) return ResponseEntity.badRequest().build();
+
+        Long memberId;
+        try {
+            memberId = jwtTokenUtil.getMemberIdFromToken(token);
+        } catch (Exception e) {
+            return ResponseEntity.status(401).build();
+        }
+
+        List<SimilarArtistResponse> response = similarArtistService.getArtistsSavedBySimilarUsers(memberId);
+        return ResponseEntity.ok(response);
+    }
+}
+

--- a/src/main/java/com/umc/banddy/domain/mypage/similarartist/web/dto/SimilarArtistResponse.java
+++ b/src/main/java/com/umc/banddy/domain/mypage/similarartist/web/dto/SimilarArtistResponse.java
@@ -1,0 +1,15 @@
+package com.umc.banddy.domain.mypage.similarartist.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SimilarArtistResponse {
+    private Long artistId;
+    private String name;
+    private String imageUrl;
+}
+

--- a/src/main/java/com/umc/banddy/domain/mypage/similartrack/converter/SimilarTrackConverter.java
+++ b/src/main/java/com/umc/banddy/domain/mypage/similartrack/converter/SimilarTrackConverter.java
@@ -1,0 +1,16 @@
+package com.umc.banddy.domain.mypage.similartrack.converter;
+
+import com.umc.banddy.domain.music.track.domain.Track;
+import com.umc.banddy.domain.mypage.similartrack.web.dto.SimilarTrackResponse;
+public class SimilarTrackConverter {
+    public static SimilarTrackResponse toResponse(Track track) {
+        return SimilarTrackResponse.builder()
+                .trackId(track.getId())
+                .title(track.getTitle())
+                .artist(track.getArtist())
+                .album(track.getAlbum())
+                .imageUrl(track.getImageUrl())
+                .build();
+    }
+}
+

--- a/src/main/java/com/umc/banddy/domain/mypage/similartrack/service/SimilarTrackService.java
+++ b/src/main/java/com/umc/banddy/domain/mypage/similartrack/service/SimilarTrackService.java
@@ -1,0 +1,38 @@
+package com.umc.banddy.domain.mypage.similartrack.service;
+
+import com.umc.banddy.domain.member.domain.Member;
+import com.umc.banddy.domain.member.repository.MemberRepository;
+import com.umc.banddy.domain.music.track.domain.Track;
+import com.umc.banddy.domain.music.track.repository.MemberTrackRepository;
+import com.umc.banddy.domain.mypage.similartrack.converter.SimilarTrackConverter;
+import com.umc.banddy.domain.mypage.similartrack.web.dto.SimilarTrackResponse;
+import com.umc.banddy.global.util.MemberSimilarityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SimilarTrackService {
+
+    private final MemberRepository memberRepository;
+    private final MemberTrackRepository memberTrackRepository;
+    private final MemberSimilarityUtil similarityUtil;
+
+    public List<SimilarTrackResponse> getTracksSavedBySimilarUsers(Long loginMemberId) {
+        Member loginMember = memberRepository.findById(loginMemberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+
+        // 유사 유저 추출
+        List<Member> similarUsers = similarityUtil.findSimilarMembers(loginMember);
+
+        // 유사 유저들이 저장한 트랙 인기순 정렬 후 상위 5개 추출
+        List<Track> tracks = memberTrackRepository.findTopSavedTracksByMembers(similarUsers, 5);
+
+        return tracks.stream()
+                .map(SimilarTrackConverter::toResponse)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/umc/banddy/domain/mypage/similartrack/web/controller/SimilarTrackController.java
+++ b/src/main/java/com/umc/banddy/domain/mypage/similartrack/web/controller/SimilarTrackController.java
@@ -1,0 +1,38 @@
+package com.umc.banddy.domain.mypage.similartrack.web.controller;
+
+import com.umc.banddy.domain.mypage.similartrack.service.SimilarTrackService;
+import com.umc.banddy.domain.mypage.similartrack.web.dto.SimilarTrackResponse;
+import com.umc.banddy.global.security.jwt.JwtTokenUtil;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tracks")
+@RequiredArgsConstructor
+@Tag(name = "비슷한 유저 곡 추천")
+public class SimilarTrackController {
+
+    private final SimilarTrackService similarTrackService;
+    private final JwtTokenUtil jwtTokenUtil;
+
+    @GetMapping("/similar")
+    public ResponseEntity<List<SimilarTrackResponse>> getSimilarTracks(HttpServletRequest request) {
+        String token = JwtTokenUtil.extractToken(request);
+        if (token == null || token.isBlank()) return ResponseEntity.badRequest().build();
+
+        Long memberId;
+        try {
+            memberId = jwtTokenUtil.getMemberIdFromToken(token);
+        } catch (Exception e) {
+            return ResponseEntity.status(401).build();
+        }
+
+        List<SimilarTrackResponse> response = similarTrackService.getTracksSavedBySimilarUsers(memberId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/umc/banddy/domain/mypage/similartrack/web/dto/SimilarTrackResponse.java
+++ b/src/main/java/com/umc/banddy/domain/mypage/similartrack/web/dto/SimilarTrackResponse.java
@@ -1,0 +1,17 @@
+package com.umc.banddy.domain.mypage.similartrack.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SimilarTrackResponse {
+    private Long trackId;
+    private String title;
+    private String artist;
+    private String album;
+    private String imageUrl;
+}
+

--- a/src/main/java/com/umc/banddy/domain/other/profile/domain/Tag.java
+++ b/src/main/java/com/umc/banddy/domain/other/profile/domain/Tag.java
@@ -1,0 +1,16 @@
+package com.umc.banddy.domain.other.profile.domain;
+
+import com.umc.banddy.global.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Tag extends BaseEntity {
+    @Id
+    private Long id;
+
+    private String name;
+}
+

--- a/src/main/java/com/umc/banddy/domain/other/profile/repository/MemberTagRepository.java
+++ b/src/main/java/com/umc/banddy/domain/other/profile/repository/MemberTagRepository.java
@@ -1,9 +1,19 @@
 package com.umc.banddy.domain.other.profile.repository;
 
+import com.umc.banddy.domain.member.domain.Member;
 import com.umc.banddy.domain.other.profile.domain.mapping.MemberTag;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MemberTagRepository extends JpaRepository<MemberTag, Long> {
+    List<MemberTag> findByMember(Member member);
+
     List<MemberTag> findByMemberId(Long memberId);
+
+    // 현재 회원을 제외한, 태그가 존재하는 모든 회원 조회 (유사도 비교용)
+    @Query("SELECT DISTINCT mt.member FROM MemberTag mt WHERE mt.member.id <> :excludeId")
+    List<Member> findAllMembersExcept(@Param("excludeId") Long excludeId);
 }

--- a/src/main/java/com/umc/banddy/global/util/MemberSimilarityUtil.java
+++ b/src/main/java/com/umc/banddy/global/util/MemberSimilarityUtil.java
@@ -1,0 +1,56 @@
+package com.umc.banddy.global.util;
+
+import com.umc.banddy.domain.member.domain.Member;
+import com.umc.banddy.domain.music.track.domain.mapping.MemberTrack;
+import com.umc.banddy.domain.other.profile.domain.mapping.MemberTag;
+import com.umc.banddy.domain.other.profile.repository.MemberTagRepository;
+import com.umc.banddy.domain.music.track.repository.MemberTrackRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class MemberSimilarityUtil {
+
+    private final MemberTagRepository memberTagRepository;
+    private final MemberTrackRepository memberTrackRepository;
+
+    /**
+     * 기준 유저와 유사한 유저들을 간단한 기준으로 찾아냄 (예: 태그 기반)
+     */
+    public List<Member> findSimilarMembers(Member me) {
+        List<MemberTag> myTags = memberTagRepository.findByMember(me);
+        Set<String> myTagNames = myTags.stream()
+                .map(MemberTag::getTagName)
+                .collect(Collectors.toSet());
+
+        // 모든 유저 가져오기
+        List<Member> allMembers = memberTagRepository.findAllMembersExcept(me.getId());
+
+        // 유사도 점수 매핑
+        Map<Member, Integer> similarityMap = new HashMap<>();
+
+        for (Member other : allMembers) {
+            List<MemberTag> otherTags = memberTagRepository.findByMember(other);
+            Set<String> otherTagNames = otherTags.stream()
+                    .map(MemberTag::getTagName)
+                    .collect(Collectors.toSet());
+
+            int common = 0;
+            for (String tag : otherTagNames) {
+                if (myTagNames.contains(tag)) common++;
+            }
+
+            if (common > 0) similarityMap.put(other, common);  // 공통 태그 ≥ 1인 유저만
+        }
+
+        return similarityMap.entrySet().stream()
+                .sorted((a, b) -> b.getValue() - a.getValue())  // 유사도 내림차순 정렬
+                .limit(10)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- #47 


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- global.util.MemberSimilarityUtil 구현하여 비슷한 유저에 대한 로직 구현
- 공통으로 겹치는 태그 개수를 통해 유사도 계산하는 간단한 방식으로 우선 구현함

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- 
