### PR TITLE
Feat: 앨범 잠금 상태 변경 기능 구현 (#66)

### DIFF
--- a/src/main/java/com/umc/banddy/domain/music/album/converter/AlbumConverter.java
+++ b/src/main/java/com/umc/banddy/domain/music/album/converter/AlbumConverter.java
@@ -1,6 +1,7 @@
 package com.umc.banddy.domain.music.album.converter;
 
 import com.umc.banddy.domain.music.album.domain.Album;
+import com.umc.banddy.domain.music.album.repository.AlbumVisibilityResponse;
 import com.umc.banddy.domain.music.album.web.dto.AlbumResponseDto;
 import com.umc.banddy.domain.music.album.web.dto.AlbumToggleResponseDto;
 
@@ -40,4 +41,12 @@ public class AlbumConverter {
                 .isSaved(isSaved)
                 .build();
     }
+
+    public static AlbumVisibilityResponse toVisibilityResponse(Long memberId, Boolean isPrivate) {
+        return AlbumVisibilityResponse.builder()
+                .memberId(memberId)
+                .isPrivate(isPrivate)
+                .build();
+    }
+
 }

--- a/src/main/java/com/umc/banddy/domain/music/album/domain/MemberAlbum.java
+++ b/src/main/java/com/umc/banddy/domain/music/album/domain/MemberAlbum.java
@@ -27,4 +27,10 @@ public class MemberAlbum extends BaseEntity {
     @JoinColumn(name = "album_id")
     private Album album;
 
+    @Column(name = "locked", nullable = false)
+    private Boolean isPrivate;
+
+    public void setIsPrivate(Boolean isPrivate) {
+        this.isPrivate = isPrivate;
+    }
 }

--- a/src/main/java/com/umc/banddy/domain/music/album/repository/AlbumVisibilityRequest.java
+++ b/src/main/java/com/umc/banddy/domain/music/album/repository/AlbumVisibilityRequest.java
@@ -1,0 +1,8 @@
+package com.umc.banddy.domain.music.album.repository;
+
+import lombok.Getter;
+
+@Getter
+public class AlbumVisibilityRequest {
+    private Boolean isPrivate;
+}

--- a/src/main/java/com/umc/banddy/domain/music/album/repository/AlbumVisibilityResponse.java
+++ b/src/main/java/com/umc/banddy/domain/music/album/repository/AlbumVisibilityResponse.java
@@ -1,0 +1,12 @@
+package com.umc.banddy.domain.music.album.repository;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AlbumVisibilityResponse {
+    private Long memberId;
+    private Boolean isPrivate;
+}
+

--- a/src/main/java/com/umc/banddy/domain/music/album/repository/MemberAlbumRepository.java
+++ b/src/main/java/com/umc/banddy/domain/music/album/repository/MemberAlbumRepository.java
@@ -12,4 +12,5 @@ public interface MemberAlbumRepository extends JpaRepository<MemberAlbum, Long> 
     Optional<MemberAlbum> findByMemberAndAlbum(Member member, Album album);
     List<MemberAlbum> findAllByMember(Member member);
     void deleteByMemberAndAlbum(Member member, Album album);
+    Optional<MemberAlbum> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/umc/banddy/domain/music/album/service/AlbumService.java
+++ b/src/main/java/com/umc/banddy/domain/music/album/service/AlbumService.java
@@ -6,6 +6,7 @@ import com.umc.banddy.domain.music.album.converter.AlbumConverter;
 import com.umc.banddy.domain.music.album.domain.Album;
 import com.umc.banddy.domain.music.album.domain.MemberAlbum;
 import com.umc.banddy.domain.music.album.repository.AlbumRepository;
+import com.umc.banddy.domain.music.album.repository.AlbumVisibilityResponse;
 import com.umc.banddy.domain.music.album.repository.MemberAlbumRepository;
 import com.umc.banddy.domain.music.album.web.dto.AlbumRequestDto;
 import com.umc.banddy.domain.music.album.web.dto.AlbumResponseDto;
@@ -160,6 +161,27 @@ public class AlbumService {
         } catch (Exception e) {
             throw new GeneralException(ErrorStatus.SPOTIFY_RESOURCE_NOT_FOUND);
         }
+    }
+
+    // 앨범 잠금 상태 수정
+    @Transactional
+    public AlbumVisibilityResponse updateAlbumVisibility(Long albumId, Boolean isPrivate, String token) {
+        Long memberId = jwtTokenUtil.getMemberIdFromToken(token);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Album album = albumRepository.findById(albumId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ALBUM_NOT_FOUND));
+
+        MemberAlbum memberAlbum = memberAlbumRepository.findByMemberAndAlbum(member, album)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ALBUM_NOT_SAVED_BY_MEMBER));
+
+        memberAlbum.setIsPrivate(isPrivate); // 잠금 상태 변경
+
+        return AlbumVisibilityResponse.builder()
+                .memberId(member.getId())
+                .isPrivate(isPrivate)
+                .build();
     }
 
 }

--- a/src/main/java/com/umc/banddy/domain/music/album/web/controller/AlbumController.java
+++ b/src/main/java/com/umc/banddy/domain/music/album/web/controller/AlbumController.java
@@ -1,5 +1,7 @@
 package com.umc.banddy.domain.music.album.web.controller;
 
+import com.umc.banddy.domain.music.album.repository.AlbumVisibilityRequest;
+import com.umc.banddy.domain.music.album.repository.AlbumVisibilityResponse;
 import com.umc.banddy.domain.music.album.service.AlbumService;
 import com.umc.banddy.domain.music.album.web.dto.AlbumRequestDto;
 import com.umc.banddy.domain.music.album.web.dto.AlbumResponseDto;
@@ -79,4 +81,18 @@ public class AlbumController {
         AlbumResponseDto result = albumService.getAlbumDetail(albumId, token);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
+
+    // 앨범 공개 여부 수정
+    @Operation(summary = "앨범 잠금 상태 변경", description = "앨범의 공개/비공개 상태를 변경합니다.")
+    @PatchMapping("/{albumId}/visibility")
+    public ResponseEntity<ApiResponse<AlbumVisibilityResponse>> updateAlbumVisibility(
+            @PathVariable Long albumId,
+            @RequestBody AlbumVisibilityRequest requestDto,
+            HttpServletRequest request
+    ) {
+        String token = JwtTokenUtil.extractToken(request);
+        AlbumVisibilityResponse result = albumService.updateAlbumVisibility(albumId, requestDto.getIsPrivate(), token);
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- #66 


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- 앨범 공개/비공개 상태를 변경하는 api 개발

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- member_album 도메인에 locked 컬럼 추가했습니다.
