### PR TITLE
Fix: 검색어 필터링 및 정렬 추가

### DIFF
--- a/src/main/java/com/umc/banddy/domain/music/search/service/AutocompleteService.java
+++ b/src/main/java/com/umc/banddy/domain/music/search/service/AutocompleteService.java
@@ -13,7 +13,9 @@ import se.michaelthelin.spotify.requests.data.search.simplified.SearchArtistsReq
 import se.michaelthelin.spotify.requests.data.search.simplified.SearchTracksRequest;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
@@ -30,9 +32,27 @@ public class AutocompleteService {
                     .limit(limit)
                     .build();
             Paging<Track> paging = request.execute();
+            String lowerQuery = query.toLowerCase();
+
             return Arrays.stream(paging.getItems())
                     .map(Track::getName)
+                    .filter(name -> name.toLowerCase().contains(lowerQuery))
                     .distinct()
+                    .sorted(Comparator.comparingInt(name -> {
+                        String lowerName = name.toLowerCase();
+                        if (lowerName.equals(lowerQuery)) {
+                            return 0; // 1. 정확히 일치
+                        } else if (lowerName.startsWith(lowerQuery + " ")) {
+                            return 1; // 2. 검색어 그대로를 가장 앞에 포함 (뒤에 공백)
+                        } else if (lowerName.startsWith(lowerQuery)) {
+                            return 2; // 3. 검색어를 가장 앞에 포함
+                        } else if (lowerName.matches(".*\\s" + Pattern.quote(lowerQuery) + ".*")) {
+                            return 3; // 4. 단어 경계(공백 뒤)
+                        } else {
+                            return 4; // 5. 그 외
+                        }
+                    }))
+                    .limit(limit)
                     .collect(Collectors.toList());
         } catch (Exception e) {
             return List.of();
@@ -45,16 +65,33 @@ public class AutocompleteService {
             SearchArtistsRequest request = spotifyApi.searchArtists(query)
                     .limit(limit)
                     .build();
-            se.michaelthelin.spotify.model_objects.specification.Paging<se.michaelthelin.spotify.model_objects.specification.Artist> paging = request.execute();
+            var paging = request.execute();
+            String lowerQuery = query.toLowerCase();
+
             return Arrays.stream(paging.getItems())
                     .map(se.michaelthelin.spotify.model_objects.specification.Artist::getName)
+                    .filter(name -> name.toLowerCase().contains(lowerQuery))
                     .distinct()
+                    .sorted(Comparator.comparingInt(name -> {
+                        String lowerName = name.toLowerCase();
+                        if (lowerName.equals(lowerQuery)) {
+                            return 0; // 1. 정확히 일치
+                        } else if (lowerName.startsWith(lowerQuery + " ")) {
+                            return 1; // 2. 검색어 그대로를 가장 앞에 포함 (뒤에 공백)
+                        } else if (lowerName.startsWith(lowerQuery)) {
+                            return 2; // 3. 검색어를 가장 앞에 포함
+                        } else if (lowerName.matches(".*\\s" + Pattern.quote(lowerQuery) + ".*")) {
+                            return 3; // 4. 단어 경계(공백 뒤)
+                        } else {
+                            return 4; // 5. 그 외
+                        }
+                    }))
+                    .limit(limit)
                     .collect(Collectors.toList());
         } catch (Exception e) {
             return List.of();
         }
     }
-
 
     public List<String> autocompleteAlbums(String query, int limit) {
         try {
@@ -63,9 +100,27 @@ public class AutocompleteService {
                     .limit(limit)
                     .build();
             Paging<AlbumSimplified> paging = request.execute();
+            String lowerQuery = query.toLowerCase();
+
             return Arrays.stream(paging.getItems())
                     .map(AlbumSimplified::getName)
+                    .filter(name -> name.toLowerCase().contains(lowerQuery))
                     .distinct()
+                    .sorted(Comparator.comparingInt(name -> {
+                        String lowerName = name.toLowerCase();
+                        if (lowerName.equals(lowerQuery)) {
+                            return 0; // 1. 정확히 일치
+                        } else if (lowerName.startsWith(lowerQuery + " ")) {
+                            return 1; // 2. 검색어 그대로를 가장 앞에 포함 (뒤에 공백)
+                        } else if (lowerName.startsWith(lowerQuery)) {
+                            return 2; // 3. 검색어를 가장 앞에 포함
+                        } else if (lowerName.matches(".*\\s" + Pattern.quote(lowerQuery) + ".*")) {
+                            return 3; // 4. 단어 경계(공백 뒤)
+                        } else {
+                            return 4; // 5. 그 외
+                        }
+                    }))
+                    .limit(limit)
                     .collect(Collectors.toList());
         } catch (Exception e) {
             return List.of();
@@ -80,24 +135,50 @@ public class AutocompleteService {
                     .limit(limit)
                     .build();
             var result = request.execute();
+            String lowerQuery = query.toLowerCase();
 
             List<String> tracks = result.getTracks() != null && result.getTracks().getItems() != null
-                    ? Arrays.stream(result.getTracks().getItems()).map(Track::getName).toList()
+                    ? Arrays.stream(result.getTracks().getItems())
+                    .map(Track::getName)
+                    .filter(name -> name.toLowerCase().contains(lowerQuery))
+                    .toList()
                     : List.of();
             List<String> artists = result.getArtists() != null && result.getArtists().getItems() != null
                     ? Arrays.stream(result.getArtists().getItems())
                     .map(se.michaelthelin.spotify.model_objects.specification.Artist::getName)
+                    .filter(name -> name.toLowerCase().contains(lowerQuery))
                     .toList()
                     : List.of();
             List<String> albums = result.getAlbums() != null && result.getAlbums().getItems() != null
-                    ? Arrays.stream(result.getAlbums().getItems()).map(AlbumSimplified::getName).toList()
+                    ? Arrays.stream(result.getAlbums().getItems())
+                    .map(AlbumSimplified::getName)
+                    .filter(name -> name.toLowerCase().contains(lowerQuery))
+                    .toList()
                     : List.of();
 
             return Arrays.asList(
-                    tracks.stream(),
-                    artists.stream(),
-                    albums.stream()
-            ).stream().flatMap(s -> s).distinct().limit(limit).collect(Collectors.toList());
+                            tracks.stream(),
+                            artists.stream(),
+                            albums.stream()
+                    ).stream()
+                    .flatMap(s -> s)
+                    .distinct()
+                    .sorted(Comparator.comparingInt(name -> {
+                        String lowerName = name.toLowerCase();
+                        if (lowerName.equals(lowerQuery)) {
+                            return 0; // 1. 정확히 일치
+                        } else if (lowerName.startsWith(lowerQuery + " ")) {
+                            return 1; // 2. 검색어 그대로를 가장 앞에 포함 (뒤에 공백)
+                        } else if (lowerName.startsWith(lowerQuery)) {
+                            return 2; // 3. 검색어를 가장 앞에 포함
+                        } else if (lowerName.matches(".*\\s" + Pattern.quote(lowerQuery) + ".*")) {
+                            return 3; // 4. 단어 경계(공백 뒤)
+                        } else {
+                            return 4; // 5. 그 외
+                        }
+                    }))
+                    .limit(limit)
+                    .collect(Collectors.toList());
         } catch (Exception e) {
             return List.of();
         }

--- a/src/main/java/com/umc/banddy/domain/music/search/web/controller/AutocompleteController.java
+++ b/src/main/java/com/umc/banddy/domain/music/search/web/controller/AutocompleteController.java
@@ -25,7 +25,7 @@ public class AutocompleteController {
     @GetMapping("/tracks")
     public ResponseEntity<ApiResponse<AutocompleteResponseDto>> autocompleteTracks(
             @RequestParam String query,
-            @RequestParam(defaultValue = "5") int limit
+            @RequestParam(defaultValue = "50") int limit
     ) {
         var results = autocompleteService.autocompleteTracks(query, limit);
         return ResponseEntity.ok(ApiResponse.onSuccess(new AutocompleteResponseDto(results)));
@@ -36,7 +36,7 @@ public class AutocompleteController {
     @GetMapping("/artists")
     public ResponseEntity<ApiResponse<AutocompleteResponseDto>> autocompleteArtists(
             @RequestParam String query,
-            @RequestParam(defaultValue = "5") int limit
+            @RequestParam(defaultValue = "50") int limit
     ) {
         var results = autocompleteService.autocompleteArtists(query, limit);
         return ResponseEntity.ok(ApiResponse.onSuccess(new AutocompleteResponseDto(results)));
@@ -47,7 +47,7 @@ public class AutocompleteController {
     @GetMapping("/albums")
     public ResponseEntity<ApiResponse<AutocompleteResponseDto>> autocompleteAlbums(
             @RequestParam String query,
-            @RequestParam(defaultValue = "5") int limit
+            @RequestParam(defaultValue = "50") int limit
     ) {
         var results = autocompleteService.autocompleteAlbums(query, limit);
         return ResponseEntity.ok(ApiResponse.onSuccess(new AutocompleteResponseDto(results)));
@@ -58,7 +58,7 @@ public class AutocompleteController {
     @GetMapping("/music")
     public ResponseEntity<ApiResponse<AutocompleteResponseDto>> autocompleteMusic(
             @RequestParam String query,
-            @RequestParam(defaultValue = "5") int limit
+            @RequestParam(defaultValue = "30") int limit
     ) {
         var results = autocompleteService.autocompleteMusic(query, limit);
         return ResponseEntity.ok(ApiResponse.onSuccess(new AutocompleteResponseDto(results)));


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- 


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- 이름에 검색어 포함한 결과만 반환하도록 필터링 추가
- 반환 결과 정렬 추가
  1. 정확히 일치 (‎`equalsIgnoreCase`)
  2. 검색어 그대로를 가장 앞에 포함 (‎`startsWith(lowerQuery + " ")` 또는 ‎`equalsIgnoreCase`)
  3. 검색어를 가장 앞에 포함 (‎`startsWith(lowerQuery)`)
  4. 단어 경계(공백 뒤) (‎`matches(".*\\s" + Pattern.quote(lowerQuery) + ".*")`)
  5. 그 외

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- 
