### PR TITLE
Fix: senderId 컨버터 및 dto에 추가

### DIFF
--- a/src/main/java/com/umc/banddy/domain/mypage/notification/converter/NotificationConverter.java
+++ b/src/main/java/com/umc/banddy/domain/mypage/notification/converter/NotificationConverter.java
@@ -12,41 +12,43 @@ import java.util.List;
 public class NotificationConverter {
 
     public static NotificationResponse fromChat(ChatNotification n) {
-        String profileImage = n.getNotification().getSender().getProfileImageUrl(); // sender 기준
-
+        var sender = n.getNotification().getSender();
         return NotificationResponse.builder()
                 .notificationId(n.getNotification().getId())
                 .title("새 메시지가 도착했습니다.")
                 .type(NotificationType.CHAT)
-                .imageUrl(profileImage)
+                .imageUrl(sender.getProfileImageUrl())
                 .createdAt(n.getNotification().getCreatedAt())
+                .senderId(sender.getId())
                 .build();
     }
 
     public static NotificationResponse fromFriend(FriendNotification n) {
-        String profileImage = n.getSender().getProfileImageUrl();
-
+        var sender = n.getSender();
         return NotificationResponse.builder()
                 .notificationId(n.getNotification().getId())
-                .title(n.getSender().getNickname() + "님이 친구 요청을 보냈습니다.")
+                .title(sender.getNickname() + "님이 친구 요청을 보냈습니다.")
                 .type(NotificationType.FRIEND)
-                .imageUrl(profileImage)
+                .imageUrl(sender.getProfileImageUrl())
                 .createdAt(n.getNotification().getCreatedAt())
+                .senderId(sender.getId())
                 .friendRequestId(n.getFriendRequest().getId())
                 .build();
     }
 
     public static NotificationResponse fromBand(BandNotification n) {
+        var sender = n.getNotification().getSender();
         return NotificationResponse.builder()
                 .notificationId(n.getNotification().getId())
                 .title(n.getTitle())
                 .type(NotificationType.BAND)
                 .imageUrl(n.getBand().getProfileImageUrl())
                 .createdAt(n.getNotification().getCreatedAt())
+                .senderId(sender.getId())
                 .build();
     }
 
-    // 통합
+    //통합
     public static List<NotificationResponse> mergeAndSort(
             List<ChatNotification> chat,
             List<FriendNotification> friend,

--- a/src/main/java/com/umc/banddy/domain/mypage/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/umc/banddy/domain/mypage/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.umc.banddy.domain.mypage.notification.repository;
+
+import com.umc.banddy.domain.mypage.notification.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/umc/banddy/domain/mypage/notification/web/dto/NotificationResponse.java
+++ b/src/main/java/com/umc/banddy/domain/mypage/notification/web/dto/NotificationResponse.java
@@ -12,6 +12,6 @@ public record NotificationResponse(
         NotificationType type,
         String imageUrl,
         LocalDateTime createdAt,
-        Long friendRequestId  //친구 요청을 알림을 위해 추가
+        Long senderId,
+        Long friendRequestId
 ) {}
-


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- 


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- senderId를 친구 요청 처리에만 넘겨주고 있었어서, 밴드 채팅 요청 등에도 반영했습니다.

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- 
