### PR TITLE
Fix: 상대방 프로필 조회 시 path variable 누락 수정

### DIFF
--- a/src/main/java/com/umc/banddy/domain/band/profile/converter/BandProfileConverter.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/converter/BandProfileConverter.java
@@ -46,10 +46,11 @@ public class BandProfileConverter {
                 .collect(Collectors.toList());
 
         CompositionDto compositionDto = CompositionDto.builder()
-                .averageAge(String.valueOf(band.getAverageAge()))
-                //.job(band.getJob())
-                .maleCount(band.getMaleCount())
-                .femaleCount(band.getFemaleCount())
+                .averageAge(
+                        band.getAverageAge() != null ? String.valueOf(band.getAverageAge()) : "정보 없음"
+                )
+                .maleCount(band.getMaleCount() != null ? band.getMaleCount() : 0)
+                .femaleCount(band.getFemaleCount() != null ? band.getFemaleCount() : 0)
                 .build();
 
         return BandProfileResponse.builder()

--- a/src/main/java/com/umc/banddy/domain/mypage/notification/service/NotificationService.java
+++ b/src/main/java/com/umc/banddy/domain/mypage/notification/service/NotificationService.java
@@ -26,6 +26,12 @@ public class NotificationService {
         List<FriendNotification> friends = friendNotificationRepository.findByNotificationReceiverId(memberId);
         List<BandNotification> bands = bandNotificationRepository.findByNotificationReceiverId(memberId);
 
+        for (FriendNotification f : friends) {
+            System.out.println("💡 알림 ID: " + f.getNotification().getId());
+            System.out.println("💡 요청 ID: " + (f.getFriendRequest() != null ? f.getFriendRequest().getId() : "null"));
+            System.out.println("💡 요청 상태: " + (f.getFriendRequest() != null ? f.getFriendRequest().getStatus() : "null"));
+        }
+
         return NotificationConverter.mergeAndSort(chats, friends, bands);
     }
 }

--- a/src/main/java/com/umc/banddy/domain/other/profile/web/controller/OtherProfileController.java
+++ b/src/main/java/com/umc/banddy/domain/other/profile/web/controller/OtherProfileController.java
@@ -22,7 +22,7 @@ public class OtherProfileController {
     private final OtherProfileService otherProfileService;
     private final JwtTokenUtil jwtTokenUtil;
 
-    // ✅ 상대방 프로필 조회
+    // 상대방 프로필 조회
     @GetMapping("/{memberId}/profile")
     public ResponseEntity<OtherProfileResponse> getOtherProfile(
             @PathVariable("memberId") Long targetMemberId,
@@ -44,7 +44,7 @@ public class OtherProfileController {
         return ResponseEntity.ok(response);
     }
 
-    // ✅ 상대방이 저장한 곡 목록 조회
+    // 상대방이 저장한 곡 목록 조회
     @GetMapping("/{memberId}/profile/saved-tracks")
     public ResponseEntity<List<SavedTrackResponse>> getSavedTracks(
             @PathVariable("memberId") Long targetMemberId
@@ -53,22 +53,12 @@ public class OtherProfileController {
         return ResponseEntity.ok(savedTracks);
     }
 
-    // ✅ 사용자 태그 조회
+    // 상대방 태그 조회
     @GetMapping("/{memberId}/tags")
-    public ResponseEntity<MemberTagResponse> getMyTags(HttpServletRequest request) {
-        String token = JwtTokenUtil.extractToken(request);
-        if (token == null || token.isBlank()) {
-            return ResponseEntity.badRequest().build();
-        }
-
-        Long memberId;
-        try {
-            memberId = jwtTokenUtil.getMemberIdFromToken(token);
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().build();
-        }
-
-        MemberTagResponse response = otherProfileService.getTagsByMemberId(memberId); // ✅ 수정된 부분
+    public ResponseEntity<MemberTagResponse> getTagsByMemberId(
+            @PathVariable("memberId") Long memberId
+    ) {
+        MemberTagResponse response = otherProfileService.getTagsByMemberId(memberId);
         return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- 


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- 상대방 프로필 조회 부분 컨트롤러 path variable 누락 수정
- 밴드 프로필 조회 시 null 사항들로 인해 조회되지 않아 테스트를 위한 null 허용 일부 추가

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- 
