### PR TITLE
feat:채팅방 참가자 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/umc/banddy/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/com/umc/banddy/domain/chat/domain/ChatRoom.java
@@ -41,8 +41,7 @@ public class ChatRoom extends BaseEntity {
     @JoinColumn(name = "chat_room_id")
     private List<ChatRoomParticipant> participants;
 
-    @OneToOne(mappedBy = "chatRoom", fetch = LAZY,
-            cascade = ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "chatRoom", fetch = LAZY, cascade = ALL, orphanRemoval = true)
     private BandChat bandChat;
 
 }

--- a/src/main/java/com/umc/banddy/domain/chat/repository/ChatRoomParticipantRepository.java
+++ b/src/main/java/com/umc/banddy/domain/chat/repository/ChatRoomParticipantRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomParticipant, Long> {
 
@@ -43,13 +44,7 @@ public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomPar
             @Param("friendIds") List<Long> friendIds
     );
 
-    boolean existsByChatRoomAndMemberAndStatus(ChatRoom chatRoom, Member member, Status status);
-
-    Optional<ChatRoomParticipant> findTopByChatRoomAndMemberAndStatusOrderByIdDesc(
-            ChatRoom chatRoom,
-            Member member,
-            Status status
-    );
+    Optional<ChatRoomParticipant> findByChatRoomAndMemberAndStatus(ChatRoom chatRoom, Member member, Status status);
 
     @Query("""
     SELECT cp.member.email
@@ -59,9 +54,7 @@ public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomPar
     """)
     List<String> findActiveEmailsByRoomId(@Param("roomId") Long roomId);
 
-    List<ChatRoomParticipant> findByMember(Member member);
-
     Optional<ChatRoomParticipant> findByChatRoomAndMember(ChatRoom chatRoom, Member member);
 
-    List<ChatRoomParticipant> findByChatRoomIdIn(List<Long> roomIds);
+    List<ChatRoomParticipant> findAllByChatRoom(ChatRoom chatRoom);
 }

--- a/src/main/java/com/umc/banddy/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/umc/banddy/domain/chat/service/ChatMessageService.java
@@ -61,7 +61,7 @@ public class ChatMessageService {
     public ChatSystemResponse exitChatRoom(ChatRoom chatRoom, Member member){
         ChatRoomParticipant chatRoomParticipant
                 = participantRepository
-                .findTopByChatRoomAndMemberAndStatusOrderByIdDesc(chatRoom, member, Status.ACTIVE)
+                .findByChatRoomAndMemberAndStatus(chatRoom, member, Status.ACTIVE)
                 .orElseThrow(() -> new IllegalStateException("참여하지 않은 채팅방입니다."));
 
         chatRoomParticipant.setStatus(Status.INACTIVE);

--- a/src/main/java/com/umc/banddy/domain/chat/service/ChatRoomParticipantCache.java
+++ b/src/main/java/com/umc/banddy/domain/chat/service/ChatRoomParticipantCache.java
@@ -1,6 +1,8 @@
 package com.umc.banddy.domain.chat.service;
 
+import com.umc.banddy.domain.chat.domain.ChatRoom;
 import com.umc.banddy.domain.chat.repository.ChatRoomParticipantRepository;
+import com.umc.banddy.domain.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/umc/banddy/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/umc/banddy/domain/chat/service/ChatRoomService.java
@@ -18,12 +18,10 @@ import com.umc.banddy.domain.member.enums.Status;
 import com.umc.banddy.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -36,6 +34,7 @@ public class ChatRoomService {
     private final MemberRepository memberRepository;
     private final FriendService friendService;
     private final FriendRepository friendRepository;
+    private final ChatRoomParticipantCache chatRoomParticipantCache;
 
     // 그룹 채팅방 생성
     public ChatRoomResponse createGroupChatRoom(Long memberId, ChatRoomRequest request){
@@ -296,15 +295,28 @@ public class ChatRoomService {
                 .build();
     }
 
-//    public ParticipantInfos getChatRoomInfo(ChatRoom chatRoom, Member member){
-//
-//
-//
-//
-//
-//
-//        return ParticipantInfos.builder()
-//                .build();
-//    }
+    @Transactional
+    public ParticipantInfos getChatRoomInfo(ChatRoom chatRoom, Member member){
+
+        List<ChatRoomParticipant> participants
+                = participantRepository.findAllByChatRoom(chatRoom);
+
+        List<ParticipantInfos.Info> infoList = new ArrayList<>();
+        for(ChatRoomParticipant participant : participants){
+            if(participant.getMember().getId().equals(member.getId())){
+                participant.setLastReadAt(LocalDateTime.now());
+            }
+            ParticipantInfos.Info info = ParticipantInfos.Info.builder()
+                    .memberId(participant.getMember().getId())
+                    .timestamp(participant.getLastReadAt())
+                    .build();
+            infoList.add(info);
+        }
+
+        return ParticipantInfos.builder()
+                .roomId(chatRoom.getId())
+                .infos(infoList)
+                .build();
+    }
 
 }

--- a/src/main/java/com/umc/banddy/domain/chat/service/ChatService.java
+++ b/src/main/java/com/umc/banddy/domain/chat/service/ChatService.java
@@ -17,9 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 @Service
@@ -45,8 +43,8 @@ public class ChatService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅방입니다. ID: " + roomId));
     }
 
-    public ChatRoomParticipant verifedParticipant(ChatRoom chatRoom, Member member, Status status) {
-        return participantRepository.findTopByChatRoomAndMemberAndStatusOrderByIdDesc(chatRoom, member,Status.ACTIVE)
+    public ChatRoomParticipant verifiedParticipant(ChatRoom chatRoom, Member member, Status status) {
+        return participantRepository.findByChatRoomAndMemberAndStatus(chatRoom, member,Status.ACTIVE)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 참여자입니다. 채팅방 ID: " + chatRoom.getId() + ", 멤버 ID: " + member.getId()));
     }
     public Long extractRoomId(String dest) {
@@ -64,7 +62,7 @@ public class ChatService {
     }
     @Transactional
     public ChatRoomParticipant markLastRead(ChatRoom chatRoom , Member member) {
-        ChatRoomParticipant participant = participantRepository.findTopByChatRoomAndMemberAndStatusOrderByIdDesc(chatRoom, member, Status.ACTIVE)
+        ChatRoomParticipant participant = participantRepository.findByChatRoomAndMemberAndStatus(chatRoom, member, Status.ACTIVE)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 참여자입니다."));
 
         participant.setLastReadAt(LocalDateTime.now());

--- a/src/main/java/com/umc/banddy/domain/chat/web/controller/ChatContoller.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/controller/ChatContoller.java
@@ -107,16 +107,16 @@ public class ChatContoller {
         return ResponseEntity.ok(chatRoomService.getFriendsChatRoom(currentMemberId));
     }
 
-//    @Operation(summary = "채팅방 정보 불러오기")
-//    @GetMapping("/rooms/{roomId}")
-//    public ResponseEntity <ParticipantInfos> getChatRoomInfo(
-//            @PathVariable Long roomId,
-//            HttpServletRequest request
-//    ){
-//        String token = JwtTokenUtil.extractToken(request);
-//        Long currentMemberId = jwtTokenUtil.getMemberIdFromToken(token);
-//        Pair<ChatRoom,Member> pair = chatService.verifedChatRoomAndMember(roomId, currentMemberId);
-//        return ResponseEntity.ok(chatRoomService.getChatRoomInfo(pair.getLeft(),pair.getRight()));
-//    }
+    @Operation(summary = "채팅방 참가자 정보 불러오기")
+    @GetMapping("/rooms/{roomId}")
+    public ResponseEntity <ParticipantInfos> getChatRoomInfo(
+            @PathVariable Long roomId,
+            HttpServletRequest request
+    ){
+        String token = JwtTokenUtil.extractToken(request);
+        Long currentMemberId = jwtTokenUtil.getMemberIdFromToken(token);
+        Pair<ChatRoom,Member> pair = chatService.verifedChatRoomAndMember(roomId, currentMemberId);
+        return ResponseEntity.ok(chatRoomService.getChatRoomInfo(pair.getLeft(),pair.getRight()));
+    }
 
 }

--- a/src/main/java/com/umc/banddy/domain/chat/web/controller/WebsocketController.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/controller/WebsocketController.java
@@ -76,7 +76,7 @@ public class WebsocketController {
         Member member = pair.getRight();
 
         // 구독 해제 시점 갱신
-        ChatRoomParticipant participant= chatService.markLastRead(chatRoom,member);
+        ChatRoomParticipant participant = chatService.markLastRead(chatRoom,member);
 
         TimeMark timeMark = TimeMark.builder()
                 .memberId(member.getId())

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/ChatRoom/ParticipantInfos.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/ChatRoom/ParticipantInfos.java
@@ -4,8 +4,27 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
 @Getter
 @AllArgsConstructor
 @Builder
 public class ParticipantInfos {
+
+    private Long roomId;
+
+    private List<Info> infos;
+
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Info{
+
+        private Long memberId;
+        private LocalDateTime timestamp;
+    }
+
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- #96 


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- GET api/chat/rooms/{roomId} 에서 채팅방 참여자 정보를 불러오는 로직 구현
- 채팅방 내부에 읽은 사람 카운팅을 위한 초기 정보 제공을 목적으로함

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- 
