### PR TITLE
Fix: 친구 요청 수락/거절 시 알림 목록에서 제거되도록 처리 (#105) 

### DIFF
--- a/src/main/java/com/umc/banddy/domain/friend/service/FriendRequestServiceImpl.java
+++ b/src/main/java/com/umc/banddy/domain/friend/service/FriendRequestServiceImpl.java
@@ -86,6 +86,8 @@ public class FriendRequestServiceImpl implements FriendRequestService {
                 .build();
 
         friendRepository.save(friend);
+        // 친구 요청 삭제
+        friendNotificationRepository.deleteByFriendRequestIdAndType(requestId, "REQUEST");
     }
 
     @Override
@@ -94,6 +96,7 @@ public class FriendRequestServiceImpl implements FriendRequestService {
         FriendRequest request = friendRequestRepository.findById(requestId)
                 .orElseThrow(() -> new IllegalArgumentException("친구 요청이 존재하지 않습니다."));
         request.setStatus(FriendStatus.REJECTED);
+        friendNotificationRepository.deleteByFriendRequestIdAndType(requestId, "REQUEST"); //
     }
 
     @Override

--- a/src/main/java/com/umc/banddy/domain/mypage/notification/repository/FriendNotificationRepository.java
+++ b/src/main/java/com/umc/banddy/domain/mypage/notification/repository/FriendNotificationRepository.java
@@ -7,5 +7,7 @@ import java.util.List;
 
 public interface FriendNotificationRepository extends JpaRepository<FriendNotification, Long> {
     List<FriendNotification> findByNotificationReceiverId(Long memberId);
+
+    void deleteByFriendRequestIdAndType(Long friendRequestId, String type); // 수락 or 거절 시 삭제를 위해 추가
 }
 


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- #105


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- FriendNotificationRepository에 deleteByFriendRequestIdAndType를 추가하여 수락 or 거절 시 알림 목록에서 해당 알림 삭제되도록 수정 

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- 
