### PR TITLE
Fix: memberAlbum locked 디폴트 값 설정

### DIFF
--- a/src/main/java/com/umc/banddy/domain/music/album/domain/MemberAlbum.java
+++ b/src/main/java/com/umc/banddy/domain/music/album/domain/MemberAlbum.java
@@ -27,8 +27,9 @@ public class MemberAlbum extends BaseEntity {
     @JoinColumn(name = "album_id")
     private Album album;
 
+    @Builder.Default
     @Column(name = "locked", nullable = false)
-    private Boolean isPrivate;
+    private Boolean isPrivate = false;
 
     public void setIsPrivate(Boolean isPrivate) {
         this.isPrivate = isPrivate;


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- x


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- member_album 테이블 locked 컬럼 not null -> 앨범 저장 시 오류 발생 -> locked 컬럼 디폴트 값 false 설정

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- 
