### PR TITLE
feat: 밴드 지원 기능 추가, 채팅방 조회 화면 변경사항 반영

### DIFF
--- a/src/main/java/com/umc/banddy/domain/band/profile/domain/mapping/BandChat.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/domain/mapping/BandChat.java
@@ -20,10 +20,10 @@ public class BandChat extends BaseEntity {
     private Long id;
 
     @Column
-    private PassFail isPass;
+    private PassFail passFail;
 
-    @ManyToOne
-    @JoinColumn(name = "chat_room_id", nullable = false)
+    @OneToOne(cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "chat_room_id", nullable = false, unique = true)
     private ChatRoom chatRoom;
 
     @ManyToOne

--- a/src/main/java/com/umc/banddy/domain/band/profile/repository/BandRepository.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/repository/BandRepository.java
@@ -1,12 +1,27 @@
 package com.umc.banddy.domain.band.profile.repository;
 
 import com.umc.banddy.domain.band.profile.domain.Band;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BandRepository extends JpaRepository<Band, Long> {
 
+
     List<Band> findByManagerId(Long managerId);
+
+    @Query("""
+    select b from Band b
+    join fetch b.bandSessions bs
+    join fetch bs.session s
+    join fetch b.manager
+    where b.id = :bandId
+""")
+    Optional<Band> findWithSessionsAndManager(@Param("bandId") Long bandId);
+
 }
 

--- a/src/main/java/com/umc/banddy/domain/band/profile/repository/BandSessionRepository.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/repository/BandSessionRepository.java
@@ -28,4 +28,6 @@ public interface BandSessionRepository extends JpaRepository<BandSession, Long> 
             @Param("bandId") Long bandId,
             @Param("status") String status
     );
+
+    Optional<BandSession> findByBandAndSessionAndSessionStatus(Band band, Session foundSession, String sessionStatus);
 }

--- a/src/main/java/com/umc/banddy/domain/band/profile/service/BandManagementService.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/service/BandManagementService.java
@@ -414,7 +414,7 @@ public class BandManagementService {
         chatRoomService.saveParticipant(savedRoom, band.getManager());
 
         BandChat bandChat = BandChat.builder()
-                .isPass(PassFail.PENDING)
+                .passFail(PassFail.PENDING)
                 .chatRoom(savedRoom)
                 .band(band)
                 .bandSession(bandSession)
@@ -469,7 +469,7 @@ public class BandManagementService {
                             .session(bandChat.getBandSession().getSession().getName())
                             .content(msg.getContent())
                             .lastMessageAt(msg.getCreatedAt())
-                            .isPass(bandChat.getIsPass())
+                            .passFail(bandChat.getPassFail())
                             .build()
             );
         }

--- a/src/main/java/com/umc/banddy/domain/band/profile/web/dto/Recruitment/BandChatSummaryDto.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/web/dto/Recruitment/BandChatSummaryDto.java
@@ -25,5 +25,5 @@ public class BandChatSummaryDto{
 
     private LocalDateTime lastMessageAt;
 
-    private PassFail isPass;
+    private PassFail passFail;
 }

--- a/src/main/java/com/umc/banddy/domain/chat/domain/enums/Role.java
+++ b/src/main/java/com/umc/banddy/domain/chat/domain/enums/Role.java
@@ -1,5 +1,5 @@
 package com.umc.banddy.domain.chat.domain.enums;
 
 public enum Role {
-    ADMIN, MEMBER
+    ADMIN, MEMBER, BANDMANAGER;
 }

--- a/src/main/java/com/umc/banddy/domain/chat/repository/ChatCustomRepository.java
+++ b/src/main/java/com/umc/banddy/domain/chat/repository/ChatCustomRepository.java
@@ -41,4 +41,6 @@ public class ChatCustomRepository {
         return cursor != null ? QChatMessage.chatMessage.id.lt(cursor) : null;
     }
 
+    //
+
 }

--- a/src/main/java/com/umc/banddy/domain/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/umc/banddy/domain/chat/repository/ChatMessageRepository.java
@@ -41,19 +41,15 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage,Long> {
 
 
     @Query("""
-        select r.id                   as roomId,
-               max(c.createdAt)       as lastMessageAt
+        select r.id             as roomId,
+               max(c.createdAt) as lastMessageAt
         from   ChatMessage c
-        join   c.chatRoom r
-        join   r.participants p
-        where  p.member = :member
-          and  r.roomType in (
-                 com.umc.banddy.domain.chat.domain.enums.RoomType.GROUP,
-                 com.umc.banddy.domain.chat.domain.enums.RoomType.BAND
-               )
-        group  by r.id
+            join   c.chatRoom r
+            join   r.participants p
+            where  p.member = :member
+            group  by r.id
     """)
-    List<LastMessageProjection> findLastMessageAtForGroupAndBandByMember(
+    List<LastMessageProjection> findLastMessageAtByMember(
             @Param("member") Member member
     );
 
@@ -70,14 +66,10 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage,Long> {
         join   c.chatRoom r
         join   r.participants p
         where  p.member    = :member
-          and  r.roomType in (
-                 com.umc.banddy.domain.chat.domain.enums.RoomType.GROUP,
-                 com.umc.banddy.domain.chat.domain.enums.RoomType.BAND
-               )
           and  c.createdAt > p.lastReadAt
         group  by r.id
     """)
-    List<UnreadCountProjection> findUnreadCountsForGroupAndBandByMember(
+    List<UnreadCountProjection> findUnreadCountsByMember(
             @Param("member") Member member
     );
 }

--- a/src/main/java/com/umc/banddy/domain/chat/repository/ChatRoomParticipantRepository.java
+++ b/src/main/java/com/umc/banddy/domain/chat/repository/ChatRoomParticipantRepository.java
@@ -15,18 +15,15 @@ import java.util.Set;
 public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomParticipant, Long> {
 
     @Query("""
-      select distinct p
-      from ChatRoomParticipant p
-      join fetch p.chatRoom r
-      join fetch r.participants rp
-      left  join fetch r.bandChat   bc
-      where p.member   = :member
-        and r.roomType in (
-          com.umc.banddy.domain.chat.domain.enums.RoomType.GROUP,
-          com.umc.banddy.domain.chat.domain.enums.RoomType.BAND
-        )
-    """)
-    List<ChatRoomParticipant> findAllGroupAndBandWithRoomParticipantsAndBandChatByMember(
+        select distinct p
+        from ChatRoomParticipant p
+            join fetch p.chatRoom r
+            join fetch r.participants rp
+            left join fetch r.bandChat bc
+        where p.member = :member
+        and p.status = 'ACTIVE'
+        """)
+    List<ChatRoomParticipant> findAllWithRoomParticipantsAndBandChatByMember(
             @Param("member") Member member
     );
 

--- a/src/main/java/com/umc/banddy/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/umc/banddy/domain/chat/repository/ChatRoomRepository.java
@@ -7,12 +7,28 @@ import com.umc.banddy.domain.chat.domain.enums.RoomType;
 import com.umc.banddy.domain.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
     List<ChatRoom> findByParticipants_MemberAndRoomType(Member member, RoomType roomType);
+
+    @Query("""
+        SELECT cr FROM ChatRoom cr
+        WHERE cr.roomType = 'PRIVATE'
+        AND cr.id IN (
+            SELECT cp1.chatRoom.id FROM ChatRoomParticipant cp1
+            JOIN ChatRoomParticipant cp2 ON cp1.chatRoom.id = cp2.chatRoom.id
+            WHERE cp1.member.id = :memberId1 AND cp2.member.id = :memberId2
+        )
+    """)
+    Optional<ChatRoom> findPrivateChatRoomByParticipants(@Param("memberId1") Long memberId1, @Param("memberId2") Long memberId2);
+
+
 }

--- a/src/main/java/com/umc/banddy/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/umc/banddy/domain/chat/service/ChatMessageService.java
@@ -173,10 +173,7 @@ public class ChatMessageService {
 
         // 성능상 개선 여지 있음
         Set<String> unsubscribedUsers = new HashSet<>(allParticipants);
-        System.out.println("roomid 참여자"+allParticipants);
-        System.out.println("세션에 구독정보"+subscribedUsers);
         unsubscribedUsers.removeAll(subscribedUsers);
-        System.out.println("차집합 정보"+unsubscribedUsers);
 
         RoomType roomType = chatRoom.getRoomType();
 
@@ -191,11 +188,11 @@ public class ChatMessageService {
                     .senderId(member.getId())
                     .roomId(chatRoom.getId())
                     .content(chatMessage.getContent())
+                    .timestamp(chatMessage.getCreatedAt())
                     .build();
             for (String email : allParticipants) {
                 if (unsubscribedUsers.contains(email)) {
-                    System.out.println("비구독자"+email);
-                    websocketService.queueUnreadMessage(email, toWsMessage(unreadResponse, MessageType.MARK_AS_UNREAD));
+                    websocketService.queueUnreadMessage(email, toWsMessage(unreadResponse, MessageType.UNREAD_MESSAGE));
                 }
             }
         } else if (roomType.equals(RoomType.PRIVATE) || roomType.equals(RoomType.BAND)) {
@@ -212,8 +209,9 @@ public class ChatMessageService {
                         .senderId(member.getId())
                         .roomId(chatRoom.getId())
                         .content(chatMessage.getContent())
+                        .timestamp(chatMessage.getCreatedAt())
                         .build();
-                websocketService.queueUnreadMessage(receiverEmail, toWsMessage(unreadResponse, MessageType.MARK_AS_UNREAD));
+                websocketService.queueUnreadMessage(receiverEmail, toWsMessage(unreadResponse, MessageType.UNREAD_MESSAGE));
             }
         }
     }

--- a/src/main/java/com/umc/banddy/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/umc/banddy/domain/chat/service/ChatRoomService.java
@@ -2,8 +2,14 @@ package com.umc.banddy.domain.chat.service;
 
 
 import com.umc.banddy.domain.band.profile.domain.Band;
+import com.umc.banddy.domain.band.profile.domain.mapping.BandChat;
+import com.umc.banddy.domain.band.profile.domain.mapping.BandSession;
+import com.umc.banddy.domain.band.profile.repository.BandChatRepository;
+import com.umc.banddy.domain.band.profile.repository.BandRepository;
+import com.umc.banddy.domain.band.profile.repository.BandSessionRepository;
 import com.umc.banddy.domain.chat.domain.ChatRoom;
 import com.umc.banddy.domain.chat.domain.ChatRoomParticipant;
+import com.umc.banddy.domain.chat.domain.enums.PassFail;
 import com.umc.banddy.domain.chat.domain.enums.Role;
 import com.umc.banddy.domain.chat.domain.enums.RoomType;
 import com.umc.banddy.domain.chat.repository.ChatMessageRepository;
@@ -16,6 +22,7 @@ import com.umc.banddy.domain.friend.service.FriendService;
 import com.umc.banddy.domain.member.domain.Member;
 import com.umc.banddy.domain.member.enums.Status;
 import com.umc.banddy.domain.member.repository.MemberRepository;
+import com.umc.banddy.domain.member.repository.SessionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -35,7 +43,10 @@ public class ChatRoomService {
     private final FriendService friendService;
     private final FriendRepository friendRepository;
     private final ChatRoomParticipantCache chatRoomParticipantCache;
-
+    private final BandRepository bandRepository;
+    private final SessionRepository sessionRepository;
+    private final BandSessionRepository bandSessionRepository;
+    private final BandChatRepository bandChatRepository;
     // 그룹 채팅방 생성
     public ChatRoomResponse createGroupChatRoom(Long memberId, ChatRoomRequest request){
         ChatRoom chatRoom = ChatRoom.builder()
@@ -84,15 +95,26 @@ public class ChatRoomService {
                 .build();
     }
 
-    // 개인 채팅방 생성
-    public PrivateChatRoomResponse createPrivateChatRoom(
-            Long memberId,
-            PrivateChatRoomRequest request
-    ) {
+    // 1:1 채팅 방 조회
+    public PrivateChatRoomResponse getPrivateChatRoom(Long memberId, Long friendId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
-        Member friend = memberRepository.findById(request.getMemberId())
+        Member friend = memberRepository.findById(friendId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 친구입니다."));
+
+        // 조회 후 없으면 생성
+        ChatRoom chatRoom = chatRoomRepository.findPrivateChatRoomByParticipants(member.getId(), friend.getId())
+                .orElseGet(() -> createPrivateChatRoom(member, friend));
+
+        return PrivateChatRoomResponse.builder()
+                .roomId(chatRoom.getId())
+                .build();
+    }
+    // 개인 채팅방 생성
+    public ChatRoom createPrivateChatRoom(
+            Member member,
+            Member friend
+    ) {
         ChatRoom chatRoom = ChatRoom.builder()
                 .name("1대1채팅")
                 .imageUrl("")
@@ -105,9 +127,7 @@ public class ChatRoomService {
         saveParticipant(savedRoom, member);
         saveParticipant(savedRoom, friend);
 
-        return PrivateChatRoomResponse.builder()
-                .roomId(savedRoom.getId())
-                .build();
+        return savedRoom;
     }
 
     public void saveParticipant(ChatRoom chatRoom, Member member) {
@@ -129,7 +149,7 @@ public class ChatRoomService {
 
         // 내 참여 정보 불러오기
         List<ChatRoomParticipant> participants
-                = participantRepository.findAllGroupAndBandWithRoomParticipantsAndBandChatByMember(member);
+                = participantRepository.findAllWithRoomParticipantsAndBandChatByMember(member);
 
         // 내가 속한 방 목록
         List<ChatRoom> myRooms = participants.stream()
@@ -142,20 +162,19 @@ public class ChatRoomService {
                 .collect(Collectors.groupingBy(ChatRoom::getRoomType));
 
         // 그룹 채팅방
-        List<ChatRoom> groupRooms =
-                roomsByType.getOrDefault(RoomType.GROUP, Collections.emptyList());
-
-        // 밴드 채팅방
-        List<ChatRoom> bandRooms =
-                roomsByType.getOrDefault(RoomType.BAND, Collections.emptyList());
-
+        List<ChatRoom> groupAndPrivateRooms = Stream.of(
+                        roomsByType.getOrDefault(RoomType.GROUP, Collections.emptyList()),
+                        roomsByType.getOrDefault(RoomType.PRIVATE, Collections.emptyList())
+                )
+                .flatMap(List::stream)
+                .toList();
 
         // 않읽은 메세지 수
         Map<Long, Long> unreadCountMap = getUnreadCountMap(member);
 
         // 마지막으로 보낸 메세지 시간
         List<ChatMessageRepository.LastMessageProjection> lasts =
-                chatMessageRepository.findLastMessageAtForGroupAndBandByMember(member);
+                chatMessageRepository.findLastMessageAtByMember(member);
         Map<Long, LocalDateTime> lastAtMap = lasts.stream()
                 .collect(Collectors.toMap(
                         ChatMessageRepository.LastMessageProjection::getRoomId,
@@ -163,7 +182,7 @@ public class ChatRoomService {
                 ));
 
         // 응답 생성
-        List<ChatRoomInfo> chatRoomInfos = groupRooms.stream()
+        List<ChatRoomInfoDto> chatRoomInfos = groupAndPrivateRooms.stream()
                 .map(room ->{
                     List<MemberInfo> memberInfos = room.getParticipants().stream()
                             .map(p -> MemberInfo.builder()
@@ -174,90 +193,227 @@ public class ChatRoomService {
                                     )
                                     .toList();
 
-                    return ChatRoomInfo.builder()
+                    return ChatRoomInfoDto.builder()
+                            .roomId(room.getId())
                             .chatName(room.getName())
                             .imageUrl(room.getImageUrl())
                             .memberInfos(memberInfos)
                             .unreadCount(unreadCountMap.get(room.getId()))
                             .lastMessageAt(lastAtMap.get(room.getId()))
                             .build();
-                }).toList();
+                }).collect(Collectors.toList());
 
+        // 밴드 채팅방
+        List<ChatRoom> bandRooms =
+                roomsByType.getOrDefault(RoomType.BAND, Collections.emptyList());
         Map<Boolean, List<ChatRoom>> partitioned = bandRooms.stream()
                 .collect(Collectors.partitioningBy(
-                        room -> room.getBandChat().getBand().getManager().equals(member)
+                        room -> room.getParticipants().stream()
+                                .anyMatch(p -> p.getRole().equals(Role.BANDMANAGER))
                 ));
 
+        List<ChatRoom> adminBandRooms = partitioned.get(true);
+        List<ChatRoom> nonAdminBandRooms = partitioned.get(false);
 
-        Map<Long, List<ChatRoom>> roomsByBand = partitioned.get(true).stream()
-                .collect(Collectors.groupingBy(
-                        room -> room.getBandChat().getBand().getId()
-                ));
-
-        List<ManagedRoomInfo> managedRoomInfos = roomsByBand.entrySet().stream()
-                .map(entry -> {
-                    Long bandId = entry.getKey();
-                    List<ChatRoom> rooms = entry.getValue();
-                    Band band = rooms.get(0).getBandChat().getBand(); // 모두 동일한 밴드
-
-                    List<InterviewRoomInfo> roomInfos = rooms.stream()
-                            .map(room -> {
-                                ChatRoomParticipant other = room.getParticipants().stream()
-                                        .filter(p -> !p.getMember().equals(member))
-                                        .findFirst()
-                                        .orElseThrow(() -> new IllegalStateException("상대 참가자가 없습니다."));
-
-                                return InterviewRoomInfo.builder()
-                                        .memberId(other.getMember().getId())
-                                        .profileImageUrl(other.getMember().getProfileImageUrl())
-                                        .session(room.getBandChat().getBandSession().getSession().toString())      // 세션 정보
-                                        .lastMessageAt(lastAtMap.get(room.getId()))
-                                        .unreadCount(unreadCountMap.getOrDefault(room.getId(), 0L))
-                                        .build();
-                                    }
+        List<ChatRoomInfoDto> nonAdminBandRoomInfos = nonAdminBandRooms.stream()
+                .map(room ->{
+                    List<MemberInfo> memberInfos = room.getParticipants().stream()
+                            .map(p -> MemberInfo.builder()
+                                    .memberId(p.getMember().getId())
+                                    .nickname(p.getMember().getNickname())
+                                    .profileImageUrl(p.getMember().getProfileImageUrl())
+                                    .build()
                             )
                             .toList();
 
-                    return ManagedRoomInfo.builder()
-                            .bandId(bandId)
-                            .bandName(band.getName())
-                            .profileImageUrl(band.getProfileImageUrl())
-                            .bandStatus(band.getStatus())
-                            .recruitingSession(
-                                    band.getBandSessions().stream()
-                                            .map(bandSession -> bandSession.getSession().toString())
-                                            .toList()
-                            )
-                            .rooms(roomInfos)
-                            .build();
-                })
-                .toList();
-
-        List<AppliedRoomInfo> appliedRoomInfos = partitioned.get(false).stream()
-                .map(room -> {
-                    Band band = room.getBandChat().getBand();
-                    return AppliedRoomInfo.builder()
-                            .bandId(band.getId())
+                    return ChatRoomInfoDto.builder()
                             .roomId(room.getId())
-                            .bandName(band.getName())
-                            .profileImageUrl(band.getProfileImageUrl())
-                            .unreadCount(unreadCountMap.getOrDefault(room.getId(), 0L))
+                            .chatName(room.getBandChat().getBand().getName())
+                            .imageUrl(room.getBandChat().getBand().getProfileImageUrl())
+                            .memberInfos(memberInfos)
+                            .unreadCount(unreadCountMap.get(room.getId()))
                             .lastMessageAt(lastAtMap.get(room.getId()))
                             .build();
+                }).collect(Collectors.toList());
+
+        List<BandManagerRoomInfoDto> adminBandRoomInfos = adminBandRooms.stream()
+                .collect(Collectors.groupingBy(room -> room.getBandChat().getBand().getId()))
+                .entrySet().stream()
+                .map(entry -> {
+                    Long bandId = entry.getKey();
+                    List<ChatRoom> rooms = entry.getValue();
+
+                    // 공통 Band 정보는 아무 room 하나에서 꺼내면 됨
+                    ChatRoom anyRoom = rooms.get(0);
+                    Band band = anyRoom.getBandChat().getBand();
+
+                    // 각 방에 대한 ChatRoomInfo 생성
+                    List<BandManagerRoomInfoDto.BandChatRoomInfo> chatRoomInfos1 = rooms.stream()
+                            .map(room -> {
+                                MemberInfo memberInfo = room.getParticipants().stream()
+                                        .map(ChatRoomParticipant::getMember)
+                                       // .filter(member1 -> !member1.getId().equals(memberId))
+                                        .map(member1 -> MemberInfo.builder()
+                                                .memberId(member1.getId())
+                                                .nickname(member1.getNickname())
+                                                .profileImageUrl(member1.getProfileImageUrl())
+                                                .build())
+                                        .findFirst()
+                                        .orElse(null);
+
+                                return BandManagerRoomInfoDto.BandChatRoomInfo.builder()
+                                        .roomId(room.getId())
+                                        .memberInfo(memberInfo)
+                                        .session(room.getBandChat().getBandSession().getSession().toString())
+                                        .passFail(room.getBandChat().getPassFail())
+                                        .lastMessageAt(lastAtMap.get(room.getId()))
+                                        .UnreadCount(unreadCountMap.get(room.getId()))
+                                        .build();
+                            })
+                            .toList();
+
+                    // 1. 전체 UnreadCount 합산
+                    long totalUnread = chatRoomInfos1.stream()
+                            .mapToLong(info -> Optional.ofNullable(info.getUnreadCount()).orElse(0L))
+                            .sum();
+
+                    LocalDateTime latest = chatRoomInfos1.stream()
+                            .map(BandManagerRoomInfoDto.BandChatRoomInfo::getLastMessageAt)
+                            .filter(Objects::nonNull)
+                            .max(LocalDateTime::compareTo)
+                            .orElse(null);
+
+                    // 밴드 단위 DTO 조립
+                    return BandManagerRoomInfoDto.builder()
+                            .bandId(band.getId())
+                            .bandName(band.getName())
+                            .bandImageUrl(band.getProfileImageUrl())
+                            .status(band.getStatus())
+                            .bandSessionList(
+                                    band.getBandSessions().stream()
+                                            .filter(session -> "RECRUITING".equals(session.getSessionStatus()))
+                                            .map(session -> session.getBand().getName())
+                                            .distinct()
+                                            .toList()
+                            )
+                            .chatRoomInfo(chatRoomInfos1)
+                            .lastMessageAt(latest)
+                            .unreadCount(totalUnread)
+                            .build();
                 })
+                .collect(Collectors.toList());
+
+        List<ChatRoomInfo> combined = Stream.concat(
+                        Stream.concat(
+                                chatRoomInfos.stream(),
+                                nonAdminBandRoomInfos.stream()
+                        ),
+                        adminBandRoomInfos.stream()
+                )
+                .sorted(Comparator.comparing(
+                        ChatRoomInfo::getLastMessageAt,
+                        Comparator.nullsFirst(Comparator.reverseOrder())
+                ))
                 .toList();
 
+//
+//
+//
+//                .map(room ->{
+//                    List<MemberInfo> memberInfos = room.getParticipants().stream()
+//                            .map(p -> MemberInfo.builder()
+//                                    .memberId(p.getMember().getId())
+//                                    .nickname(p.getMember().getNickname())
+//                                    .profileImageUrl(p.getMember().getProfileImageUrl())
+//                                    .build()
+//                            )
+//                            .toList();
+//
+//                    return BandManagerRoomInfoDto.builder()
+//                            .roomId(room.getId())
+//                            .chatName(room.getBandChat().getBand().getName())
+//                            .imageUrl(room.getBandChat().getBand().getProfileImageUrl())
+//                            .memberInfos(memberInfos)
+//                            .unreadCount(unreadCountMap.get(room.getId()))
+//                            .lastMessageAt(lastAtMap.get(room.getId()))
+//                            .build();
+//                }).collect(Collectors.toList());
+//
+//
+//
+//        Map<Boolean, List<ChatRoom>> partitioned = bandRooms.stream()
+//                .collect(Collectors.partitioningBy(
+//                        room -> room.getBandChat().getBand().getManager().equals(member)
+//                ));
+//
+//
+//        Map<Long, List<ChatRoom>> roomsByBand = partitioned.get(true).stream()
+//                .collect(Collectors.groupingBy(
+//                        room -> room.getBandChat().getBand().getId()
+//                ));
+//
+//        List<ManagedRoomInfo> managedRoomInfos = roomsByBand.entrySet().stream()
+//                .map(entry -> {
+//                    Long bandId = entry.getKey();
+//                    List<ChatRoom> rooms = entry.getValue();
+//                    Band band = rooms.get(0).getBandChat().getBand(); // 모두 동일한 밴드
+//
+//                    List<InterviewRoomInfo> roomInfos = rooms.stream()
+//                            .map(room -> {
+//                                ChatRoomParticipant other = room.getParticipants().stream()
+//                                        .filter(p -> !p.getMember().equals(member))
+//                                        .findFirst()
+//                                        .orElseThrow(() -> new IllegalStateException("상대 참가자가 없습니다."));
+//
+//                                return InterviewRoomInfo.builder()
+//                                        .memberId(other.getMember().getId())
+//                                        .profileImageUrl(other.getMember().getProfileImageUrl())
+//                                        .session(room.getBandChat().getBandSession().getSession().toString())      // 세션 정보
+//                                        .lastMessageAt(lastAtMap.get(room.getId()))
+//                                        .unreadCount(unreadCountMap.getOrDefault(room.getId(), 0L))
+//                                        .build();
+//                                    }
+//                            )
+//                            .toList();
+//
+//                    return ManagedRoomInfo.builder()
+//                            .bandId(bandId)
+//                            .bandName(band.getName())
+//                            .profileImageUrl(band.getProfileImageUrl())
+//                            .bandStatus(band.getStatus())
+//                            .recruitingSession(
+//                                    band.getBandSessions().stream()
+//                                            .map(bandSession -> bandSession.getSession().toString())
+//                                            .toList()
+//                            )
+//                            .rooms(roomInfos)
+//                            .build();
+//                })
+//                .toList();
+//
+//        List<AppliedRoomInfo> appliedRoomInfos = partitioned.get(false).stream()
+//                .map(room -> {
+//                    Band band = room.getBandChat().getBand();
+//                    return AppliedRoomInfo.builder()
+//                            .bandId(band.getId())
+//                            .roomId(room.getId())
+//                            .bandName(band.getName())
+//                            .profileImageUrl(band.getProfileImageUrl())
+//                            .unreadCount(unreadCountMap.getOrDefault(room.getId(), 0L))
+//                            .lastMessageAt(lastAtMap.get(room.getId()))
+//                            .build();
+//                })
+//                .toList();
+
         return ChatRoomListResponse.builder()
-                .chatRoomInfos(chatRoomInfos)
-                .managedRoomInfos(managedRoomInfos)
-                .appliedRoomInfos(appliedRoomInfos)
+                .chatRoomInfos(combined)
                 .build();
 
     }
 
     public Map<Long, Long> getUnreadCountMap(Member member) {
         List<ChatMessageRepository.UnreadCountProjection> list =
-                chatMessageRepository.findUnreadCountsForGroupAndBandByMember(member);
+                chatMessageRepository.findUnreadCountsByMember(member);
 
         return list.stream()
                 .collect(Collectors.toMap(
@@ -316,6 +472,55 @@ public class ChatRoomService {
         return ParticipantInfos.builder()
                 .roomId(chatRoom.getId())
                 .infos(infoList)
+                .build();
+    }
+
+    @Transactional
+    public GroupChatRoomResponse joinBand(Long bandId, Long memberId, String session){
+
+        Band band = bandRepository.findWithSessionsAndManager(bandId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 밴드입니다. ID: " + bandId));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다. ID: " + memberId));
+
+        ChatRoom chatRoom = ChatRoom.builder()
+                .name(band.getName())
+                .imageUrl("")
+                .roomType(RoomType.BAND)
+                .build();
+
+        BandSession bandSession= band.getBandSessions().stream()
+                .filter(bs -> bs.getSessionStatus().equals("RECRUITING"))
+                .filter(bs -> bs.getSession().getName().equals(session))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 상태의 밴드 세션입니다: " + session));
+
+       bandChatRepository.save(
+                BandChat.builder()
+                        .band(band)
+                        .passFail(PassFail.PENDING)
+                        .bandSession(bandSession)
+                        .chatRoom(chatRoom)
+                        .build()
+       );
+
+        // 참여자 추가
+        saveParticipant(chatRoom, member);
+        ChatRoomParticipant bandManager = ChatRoomParticipant.builder()
+                .chatRoom(chatRoom)
+                .member(band.getManager())
+                .role(Role.BANDMANAGER)  // 기본 역할 설정
+                .status(Status.ACTIVE)  // 기본 상태 설정
+                .lastReadAt(LocalDateTime.now())  // 초기값
+                .build();
+        participantRepository.save(bandManager);
+        return GroupChatRoomResponse.builder()
+                .roomId(chatRoom.getId())
+                .bandName(band.getName())
+                .bandProfileUrl(band.getProfileImageUrl())
+                .managerId(bandManager.getId())
+                .managerName(band.getManager().getNickname())
+                .managerProfileUrl(band.getManager().getProfileImageUrl())
                 .build();
     }
 

--- a/src/main/java/com/umc/banddy/domain/chat/service/WebsocketService.java
+++ b/src/main/java/com/umc/banddy/domain/chat/service/WebsocketService.java
@@ -25,7 +25,6 @@ public class WebsocketService {
         );
     }
     public <M> void queueUnreadMessage(String receiverEmail, M message ) {
-        System.out.println("[DEBUG] convertAndSendToUser 호출 대상 email = " +receiverEmail);
         messagingTemplate.convertAndSendToUser(
                 receiverEmail,
                 "/queue/unread",

--- a/src/main/java/com/umc/banddy/domain/chat/web/controller/ChatContoller.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/controller/ChatContoller.java
@@ -39,7 +39,7 @@ public class ChatContoller {
         return ResponseEntity.ok(chatRoomService.createGroupChatRoom(currentMemberId, chatRoomRequest));
     }
 
-    @Operation(summary = "개인 채팅방 생성", description = "개인 채팅방 생성 api")
+    @Operation(summary = "개인 채팅방 조회")
     @PostMapping("/rooms/friends")
     public ResponseEntity<PrivateChatRoomResponse> createPrivateChatRooms(
             @RequestBody @Valid PrivateChatRoomRequest privateChatRoomRequest,
@@ -47,7 +47,7 @@ public class ChatContoller {
     ) {
         String token = JwtTokenUtil.extractToken(request);
         Long currentMemberId = jwtTokenUtil.getMemberIdFromToken(token);
-        return ResponseEntity.ok(chatRoomService.createPrivateChatRoom(currentMemberId, privateChatRoomRequest));
+        return ResponseEntity.ok(chatRoomService.getPrivateChatRoom(currentMemberId, privateChatRoomRequest.getMemberId()));
     }
 
     @Operation(summary="채팅 참여")
@@ -119,4 +119,15 @@ public class ChatContoller {
         return ResponseEntity.ok(chatRoomService.getChatRoomInfo(pair.getLeft(),pair.getRight()));
     }
 
+    @Operation(summary = "밴드 지원하기")
+    @PostMapping("/bands/{bandId}/join")
+    public ResponseEntity<GroupChatRoomResponse> joinBand(
+            @PathVariable Long bandId,
+            @RequestBody @Valid BandJoinRequest bandJoinRequest,
+            HttpServletRequest request
+    ) {
+        String token = JwtTokenUtil.extractToken(request);
+        Long currentMemberId = jwtTokenUtil.getMemberIdFromToken(token);
+        return ResponseEntity.ok(chatRoomService.joinBand(bandId, currentMemberId, bandJoinRequest.getSession()));
+    }
 }

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/ChatRoom/BandJoinRequest.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/ChatRoom/BandJoinRequest.java
@@ -4,13 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
-
 @Getter
 @AllArgsConstructor
 @Builder
-public class ChatRoomListResponse {
+public class BandJoinRequest {
 
-    private List<ChatRoomInfo> chatRoomInfos;
-
+    private String session;
 }

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/ChatRoom/BandManagerRoomInfoDto.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/ChatRoom/BandManagerRoomInfoDto.java
@@ -1,0 +1,42 @@
+package com.umc.banddy.domain.chat.web.dto.ChatRoom;
+
+
+import com.umc.banddy.domain.band.profile.domain.mapping.BandSession;
+import com.umc.banddy.domain.band.profile.enums.BandStatus;
+import com.umc.banddy.domain.chat.domain.enums.PassFail;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@SuperBuilder
+public class BandManagerRoomInfoDto extends ChatRoomInfo{
+
+
+    private Long bandId;
+
+    private String bandImageUrl;
+
+    private String bandName;
+
+    private BandStatus status;
+
+    private List<String> bandSessionList;
+
+    private List<BandChatRoomInfo> chatRoomInfo;
+
+
+    @Getter
+    @Builder
+    public static class BandChatRoomInfo {
+        private Long roomId;
+        private MemberInfo memberInfo;
+        private String session;
+        private PassFail passFail;
+        private LocalDateTime lastMessageAt;
+        private Long UnreadCount;
+    }
+}

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/ChatRoom/ChatRoomInfoDto.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/ChatRoom/ChatRoomInfoDto.java
@@ -5,18 +5,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
 @SuperBuilder
-public abstract class ChatRoomInfo {
+public class ChatRoomInfoDto extends ChatRoomInfo{
 
-    private String chatName;
+    private Long roomId;
+    private List<MemberInfo> memberInfos;
 
-    private String imageUrl;
-
-    private Long unreadCount;
-
-    private LocalDateTime lastMessageAt;
 }

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/ChatRoom/GroupChatRoomResponse.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/ChatRoom/GroupChatRoomResponse.java
@@ -1,0 +1,24 @@
+ package com.umc.banddy.domain.chat.web.dto.ChatRoom;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class GroupChatRoomResponse {
+
+    private Long roomId;
+
+    private String bandName;
+
+    private String bandProfileUrl;
+
+    private Long managerId;
+
+    private String managerName;
+
+    private String managerProfileUrl;
+}

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/Message/ChatMessageRequest.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/Message/ChatMessageRequest.java
@@ -24,7 +24,7 @@ public class ChatMessageRequest {
     // roomType이 GROUP일 땐 receiverId가 반드시 null
     @AssertTrue
     public boolean isReceiverValid() {
-        if (roomType == RoomType.PRIVATE) {
+        if (roomType == RoomType.PRIVATE || roomType == RoomType.BAND) {
             return receiverId != null;
         } else {
             return receiverId == null;

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/Message/UnreadResponse.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/Message/UnreadResponse.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @AllArgsConstructor
 @Builder
@@ -12,5 +14,6 @@ public class UnreadResponse {
     private Long senderId;
     private Long roomId;
     private String content;
+    private LocalDateTime timestamp;
 
 }

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/MessageType.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/MessageType.java
@@ -6,5 +6,6 @@ public enum MessageType {
     LEAVE, // 퇴장 메시지
     SYSTEM, // 시스템 메시지
     MARk_AS_READ, // 읽음 표시 메시지
-    MARK_AS_UNREAD // 읽지 않음 표시 메시지
+    MARK_AS_UNREAD, // 읽지 않음 표시 메시지
+    UNREAD_MESSAGE
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- #94 #99 


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- 밴드 조인으로 채팅방 생성 기능 구현
- 밴드 조인시 band 매니저는 bandManager 역할부여
- 채팅방화면 밴드지원/밴드관리/단체로 나눠지던 개인 채팅도 추가하고 lastMessageAt 순서로 정렬
- 밴드 관리는 내부 채팅방 정보 합쳐서 lastmessageAt, unreadcount 표시
- 개인 채팅방 조회를 조회 기능과 생성 기능 병합
- bandchat의 속성 isPass > passFail로 이름 변경

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->

