### PR TITLE
Fix: 폴더 자식 엔티티 연관관계 JPA cascade 옵션 추가 (#116)

### DIFF
--- a/src/main/java/com/umc/banddy/domain/music/folder/domain/AlbumFolder.java
+++ b/src/main/java/com/umc/banddy/domain/music/folder/domain/AlbumFolder.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -23,4 +25,7 @@ public class AlbumFolder extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "albumFolder", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<FolderAlbums> folderAlbums;
 }

--- a/src/main/java/com/umc/banddy/domain/music/folder/domain/ArtistFolder.java
+++ b/src/main/java/com/umc/banddy/domain/music/folder/domain/ArtistFolder.java
@@ -5,6 +5,8 @@ import com.umc.banddy.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -20,4 +22,7 @@ public class ArtistFolder extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "artistFolder", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<FolderArtists> folderArtists;
 }

--- a/src/main/java/com/umc/banddy/domain/music/folder/domain/TrackFolder.java
+++ b/src/main/java/com/umc/banddy/domain/music/folder/domain/TrackFolder.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -22,4 +24,7 @@ public class TrackFolder extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "trackFolder", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<FolderTracks> folderTracks;
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- #116 


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- 폴더 자식 엔티티 연관관계 JPA cascade 옵션 추가
- 곡, 아티스트, 앨범 폴더 모두 적용
  - `TrackFolder` 엔티티에서 자식 엔티티(‎`FolderTracks` 등)와의 연관관계에
‎`cascade = CascadeType.REMOVE` 또는 ‎`cascade = CascadeType.ALL`
그리고 ‎`orphanRemoval = true`를 추가 -> `trackFolderRepository.delete(folder)` 호출 시
해당 폴더에 속한 모든 ‎`FolderTracks`(자식 데이터)도 자동으로 삭제 -> 폴더 안에 아이템 있어도 폴더 삭제 가능

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- 
