### PR TITLE
fix : 채팅방 조회 기능 오류 수정

### DIFF
--- a/src/main/java/com/umc/banddy/domain/band/profile/service/BandDetailService.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/service/BandDetailService.java
@@ -26,7 +26,7 @@ public class BandDetailService {
     private final BandTagRepository bandTagRepository;
     private final BandTrackRepository bandTrackRepository;
 
-    public BandDetailResponse getBandDetail(Long bandId, Long loginMemberId) {
+    public BandDetailResponse getBandDetail(Long loginMemberId, Long bandId) {
         Band band = bandRepository.findById(bandId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 밴드가 존재하지 않습니다."));
 

--- a/src/main/java/com/umc/banddy/domain/band/profile/service/BandManagementService.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/service/BandManagementService.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -428,9 +429,7 @@ public class BandManagementService {
         ChatRoom savedRoom = chatRoomRepository.save(chatRoom);
 
         // 참여자 추가
-        chatRoomService.saveParticipant(savedRoom, member);
-        chatRoomService.saveParticipant(savedRoom, band.getManager());
-
+        chatRoomService.saveBandParticipant(chatRoom, member, band.getManager());
         BandChat bandChat = BandChat.builder()
                 .passFail(PassFail.PENDING)
                 .chatRoom(savedRoom)

--- a/src/main/java/com/umc/banddy/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/umc/banddy/domain/chat/repository/ChatRoomRepository.java
@@ -18,15 +18,16 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     List<ChatRoom> findByParticipants_MemberAndRoomType(Member member, RoomType roomType);
 
     @Query("""
-        SELECT cr FROM ChatRoom cr
-        WHERE cr.roomType = 'PRIVATE'
-        AND cr.id IN (
-            SELECT cp1.chatRoom.id FROM ChatRoomParticipant cp1
-            JOIN ChatRoomParticipant cp2 ON cp1.chatRoom.id = cp2.chatRoom.id
-            WHERE cp1.member.id = :memberId1 AND cp2.member.id = :memberId2
-        )
-    """)
-    Optional<ChatRoom> findPrivateChatRoomByParticipants(@Param("memberId1") Long memberId1, @Param("memberId2") Long memberId2);
+    SELECT DISTINCT cr FROM ChatRoom cr
+    JOIN FETCH cr.participants cp
+    WHERE cr.roomType = 'PRIVATE'
+    AND cr.id IN (
+        SELECT cp1.chatRoom.id FROM ChatRoomParticipant cp1
+        JOIN ChatRoomParticipant cp2 ON cp1.chatRoom.id = cp2.chatRoom.id
+        WHERE cp1.member.id = :memberId1 AND cp2.member.id = :memberId2
+    )
+""")
+    List<ChatRoom> findPrivateChatRoomByParticipants(@Param("memberId1") Long memberId1, @Param("memberId2") Long memberId2);
 
 
     @EntityGraph(attributePaths = {"bandChat"})

--- a/src/main/java/com/umc/banddy/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/umc/banddy/domain/chat/service/ChatMessageService.java
@@ -194,8 +194,8 @@ public class ChatMessageService {
                     websocketService.queueUnreadMessage(email, toWsMessage(unreadResponse, MessageType.UNREAD_MESSAGE));
                 }
             }
-        } else if (roomType.equals(RoomType.PRIVATE) || roomType.equals(RoomType.BAND)) {
-            // PRIVATE, BAND: 세션 단위로 유저에게 개별 전송
+        } else if (roomType.equals(RoomType.PRIVATE) ) {
+            // PRIVATE: 세션 단위로 유저에게 개별 전송
             Long receiverId = Optional.ofNullable(messageRequest.getReceiverId())
                     .orElseThrow(() -> new IllegalArgumentException("receiverId가 필요합니다."));
             // 캐싱 고려
@@ -209,10 +209,31 @@ public class ChatMessageService {
                         .build();
                 websocketService.queueUnreadMessage(receiverEmail, toWsMessage(unreadResponse, MessageType.UNREAD_MESSAGE));
 
-            }else{
+            } else {
                 ChatMessageResponse chatMessageResponse = chatToResponse(chatMessage);
                 websocketService.queuePrivateMessage(receiverEmail, roomId, toWsMessage(chatMessageResponse, MessageType.MESSAGE));
             }
+        } else if (roomType.equals(RoomType.BAND)) {
+            // BAND: 세션 단위로 유저에게 개별 전송
+            Long receiverId = Optional.ofNullable(messageRequest.getReceiverId())
+                    .orElseThrow(() -> new IllegalArgumentException("receiverId가 필요합니다."));
+            // 캐싱 고려
+            String receiverEmail = memberRepository.findEmailById(receiverId);
+            if (unsubscribedUsers.contains(receiverEmail)) {
+                UnreadBandResponse unreadbandResponse = UnreadBandResponse.builder()
+                        .senderId(member.getId())
+                        .roomId(chatRoom.getId())
+                        .bandId(chatRoom.getBandChat().getBand().getId())
+                        .content(chatMessage.getContent())
+                        .timestamp(chatMessage.getCreatedAt())
+                        .build();
+                websocketService.queueUnreadMessage(receiverEmail, toWsMessage(unreadbandResponse, MessageType.UNREAD_MESSAGE));
+
+            } else {
+                ChatMessageResponse chatMessageResponse = chatToResponse(chatMessage);
+                websocketService.queuePrivateMessage(receiverEmail, roomId, toWsMessage(chatMessageResponse, MessageType.MESSAGE));
+            }
+
         }
     }
 

--- a/src/main/java/com/umc/banddy/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/umc/banddy/domain/chat/service/ChatRoomService.java
@@ -152,8 +152,16 @@ public class ChatRoomService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 친구입니다."));
 
         // 조회 후 없으면 생성
-        ChatRoom chatRoom = chatRoomRepository.findPrivateChatRoomByParticipants(member.getId(), friend.getId())
+        ChatRoom chatRoom = chatRoomRepository.findPrivateChatRoomByParticipants(member.getId(), friend.getId()).stream()
+                .findFirst()
                 .orElseGet(() -> createPrivateChatRoom(member, friend));
+
+        chatRoom.getParticipants().forEach(participant -> {
+            if (participant.getStatus() == Status.INACTIVE) {
+                participant.setStatus(Status.ACTIVE);
+            }
+        });
+
 
         return PrivateChatRoomResponse.builder()
                 .roomId(chatRoom.getId())
@@ -190,6 +198,27 @@ public class ChatRoomService {
 
         participantRepository.save(participant);
     }
+
+    public void saveBandParticipant(ChatRoom chatRoom, Member member, Member Manager) {
+        ChatRoomParticipant participantMember = ChatRoomParticipant.builder()
+                .chatRoom(chatRoom)
+                .member(member)
+                .role(Role.MEMBER)  // 기본 역할 설정
+                .status(Status.ACTIVE)  // 기본 상태 설정
+                .lastReadAt(LocalDateTime.now())  // 초기값
+                .build();
+        ChatRoomParticipant participantManager = ChatRoomParticipant.builder()
+                .chatRoom(chatRoom)
+                .member(member)
+                .role(Role.BANDMANAGER)  // 기본 역할 설정
+                .status(Status.ACTIVE)  // 기본 상태 설정
+                .lastReadAt(LocalDateTime.now())  // 초기값
+                .build();
+        List<ChatRoomParticipant> participants = List.of(participantMember, participantManager);
+
+        participantRepository.saveAll(participants);
+    }
+
 
     public ChatRoomListResponse getMyChatRooms(Long memberId){
 
@@ -241,6 +270,7 @@ public class ChatRoomService {
                 ));
 
         // 응답 생성
+        // 그룹 채팅방 정보 생성
         List<ChatRoomInfoDto> groupChatRoomInfos = groupRooms.stream()
                 .map(room ->{
                     List<MemberInfo> memberInfos = room.getParticipants().stream()
@@ -263,6 +293,7 @@ public class ChatRoomService {
                             .build();
                 }).collect(Collectors.toList());
 
+        // 개인 채팅방 정보 생성
         List<PrivateChatRoomInfoDto> privateChatRoomInfos = privateRooms.stream()
                 .map(room ->{
 
@@ -280,8 +311,8 @@ public class ChatRoomService {
                     return PrivateChatRoomInfoDto.builder()
                             .roomType(String.valueOf(RoomType.PRIVATE))
                             .roomId(room.getId())
-                            .chatName(room.getName())
-                            .imageUrl(room.getImageUrl())
+                            .chatName(memberInfo.getNickname())
+                            .imageUrl(memberInfo.getProfileImageUrl())
                             .memberInfo(memberInfo)
                             .unreadCount(unreadCountMap.get(room.getId()))
                             .lastMessageAt(lastAtMap.get(room.getId()))
@@ -321,10 +352,8 @@ public class ChatRoomService {
 
         List<BandManagerRoomInfoDto> adminBandRoomInfos = adminBandRooms.stream()
                 .collect(Collectors.groupingBy(room -> room.getBandChat().getBand().getId()))
-                .entrySet().stream()
-                .map(entry -> {
-                    Long bandId = entry.getKey();
-                    List<ChatRoom> rooms = entry.getValue();
+                .values().stream()
+                .map(rooms -> {
 
                     ChatRoom anyRoom = rooms.get(0);
                     Band band = anyRoom.getBandChat().getBand();
@@ -334,7 +363,7 @@ public class ChatRoomService {
                             .map(room -> {
                                 MemberInfo memberInfo = room.getParticipants().stream()
                                         .map(ChatRoomParticipant::getMember)
-                                       // .filter(member1 -> !member1.getId().equals(memberId))
+                                        .filter(member1 -> !member1.getId().equals(memberId))
                                         .map(member1 -> MemberInfo.builder()
                                                 .memberId(member1.getId())
                                                 .nickname(member1.getNickname())
@@ -346,7 +375,7 @@ public class ChatRoomService {
                                 return BandManagerRoomInfoDto.BandChatRoomInfo.builder()
                                         .roomId(room.getId())
                                         .memberInfo(memberInfo)
-                                        .session(room.getBandChat().getBandSession().getSession().toString())
+                                        .session(room.getBandChat().getBandSession().getSession().getName())
                                         .passFail(room.getBandChat().getPassFail())
                                         .lastMessageAt(lastAtMap.get(room.getId()))
                                         .UnreadCount(unreadCountMap.get(room.getId()))
@@ -375,7 +404,7 @@ public class ChatRoomService {
                             .bandSessionList(
                                     band.getBandSessions().stream()
                                             .filter(session -> "RECRUITING".equals(session.getSessionStatus()))
-                                            .map(session -> session.getBand().getName())
+                                            .map(session -> session.getSession().getName())
                                             .distinct()
                                             .toList()
                             )

--- a/src/main/java/com/umc/banddy/domain/chat/web/controller/ChatContoller.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/controller/ChatContoller.java
@@ -30,7 +30,6 @@ public class ChatContoller {
     private final JwtTokenUtil jwtTokenUtil;
     private final ChatMessageService chatMessageService;
 
-
     @Operation(summary = " 단체 채팅방 생성", description = "단체 채팅방 생성 api")
     @PostMapping(path = "/rooms", consumes = "multipart/form-data")
     public ResponseEntity<ChatRoomResponse> createChatRoom(

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/roomlist/ChatRoomInfo.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/roomlist/ChatRoomInfo.java
@@ -11,10 +11,6 @@ public abstract class ChatRoomInfo {
 
     private String roomType;
 
-    private String chatName;
-
-    private String imageUrl;
-
     private Long unreadCount;
 
     private LocalDateTime lastMessageAt;

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/roomlist/ChatRoomInfoDto.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/roomlist/ChatRoomInfoDto.java
@@ -11,6 +11,10 @@ import java.util.List;
 public class ChatRoomInfoDto extends ChatRoomInfo {
 
     private Long roomId;
+
+    private String chatName;
+
+    private String imageUrl;
     private List<MemberInfo> memberInfos;
 
 }

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/roomlist/PrivateChatRoomInfoDto.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/roomlist/PrivateChatRoomInfoDto.java
@@ -11,6 +11,10 @@ import java.util.List;
 public class PrivateChatRoomInfoDto extends ChatRoomInfo {
 
     private Long roomId;
+
+    private String chatName;
+
+    private String imageUrl;
     private MemberInfo memberInfo;
 
 }

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/message/UnreadBandResponse.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/message/UnreadBandResponse.java
@@ -1,0 +1,20 @@
+package com.umc.banddy.domain.chat.web.dto.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class UnreadBandResponse {
+
+    private Long senderId;
+    private Long roomId;
+    private Long bandId;
+    private String content;
+    private LocalDateTime timestamp;
+
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- 


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- 밴드 프로필 조회 인자 수정
- 밴드 채팅방 생성시 매니저가 member 권한으로 생성되던 오류 수정
- 채팅방 조회시 band-manager에서 비정상적으로 session를 조회하던 오류 수정
- 밴드 채팅시 unreadmessage에서 bandId도 같이 보내도록 수정
- 채팅방 조회시 개인 채팅방에서는 상대 참여자 정보가 이름, 프로필에 표시 되도록 수정
- 개인 채팅방 생성시 비활성화 된 참가자를 활성화 시키는 로직 추가

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- 
