### PR TITLE
Feat: pin기능 완성, 채팅방 없는 밴드조회 되도록 수정, 메세지 형식 추가및 통일

### DIFF
--- a/src/main/java/com/umc/banddy/domain/band/profile/converter/BandProfileConverter.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/converter/BandProfileConverter.java
@@ -42,7 +42,7 @@ public class BandProfileConverter {
                 .collect(Collectors.toList());
 
         List<String> jobList = jobs.stream()
-                .map(bj -> bj.getJob())
+                .map(BandJob::getJob)
                 .collect(Collectors.toList());
 
         CompositionDto compositionDto = CompositionDto.builder()

--- a/src/main/java/com/umc/banddy/domain/band/profile/domain/Band.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/domain/Band.java
@@ -84,6 +84,9 @@ public class Band extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = true)
     private Member manager;
 
+    @Column(name = "pinned_at", nullable = true)
+    private LocalDateTime pinnedAt;
+
     @Builder.Default
     @OneToMany(mappedBy = "band", fetch = FetchType.LAZY,
             cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/umc/banddy/domain/band/profile/repository/BandRepository.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/repository/BandRepository.java
@@ -23,5 +23,12 @@ public interface BandRepository extends JpaRepository<Band, Long> {
 """)
     Optional<Band> findWithSessionsAndManager(@Param("bandId") Long bandId);
 
+    @Query("""
+        select b
+          from Band b
+         where b.manager.id = :managerId
+           and b.status <> com.umc.banddy.domain.band.profile.enums.BandStatus.ENDED
+        """)
+    List<Band> findAllActiveByManagerId(@Param("managerId") Long managerId);
 }
 

--- a/src/main/java/com/umc/banddy/domain/band/profile/service/BandManagementService.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/service/BandManagementService.java
@@ -531,24 +531,31 @@ public class BandManagementService {
                 .build();
     }
 
-    public ApplicationListResponse updateApplicant(Long memberId, ApplicantUpdateRequest request, Long bandId) {
-
-        Map<Long, String> a = request.getApplicantUpdate();
-        List<Long> roomIds = new ArrayList<>(a.keySet());
-
-
+    @Transactional
+    public ApplicationListResponse updateApplicant(
+            Long memberId,
+            ApplicantUpdateRequest request,
+            Long bandId
+    ) {
+        List<Long> roomIds = request.getApplicantUpdate().stream()
+                .map(ApplicantUpdateRequest.ApplicantUpdateDto::getRoomId)
+                .toList();
 
         List<ChatRoom> chatRooms = chatRoomRepository.findByIdIn(roomIds);
 
+        Map<Long, String> statusMap = request.getApplicantUpdate().stream()
+                .collect(Collectors.toMap(
+                        ApplicantUpdateRequest.ApplicantUpdateDto::getRoomId,
+                        ApplicantUpdateRequest.ApplicantUpdateDto::getStatus
+                ));
+
         chatRooms.forEach(chatRoom -> {
-            String status = a.get(chatRoom.getId());
-            if (status != null) {
-                chatRoom.getBandChat().setPassFail(PassFail.valueOf(status));
+            String statusStr = statusMap.get(chatRoom.getId());
+            if (statusStr != null) {
+                chatRoom.getBandChat()
+                        .setPassFail(PassFail.valueOf(statusStr));
             }
         });
-
-
-
 
         return getApplicationList(bandId, memberId);
     }

--- a/src/main/java/com/umc/banddy/domain/band/profile/web/controller/BandManagementController.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/web/controller/BandManagementController.java
@@ -23,7 +23,20 @@ public class BandManagementController {
     private final ChatRoomService chatRoomService;
 
 
-    @Operation(summary = "밴드 모집방 만들기")
+    @Operation(summary = "밴드 모집방 만들기" ,description = """
+    - 세션 타입 "🎤 보컬 🎤" , "🎸 일렉 기타 " , "🪕 어쿠스틱 기타 🪕" ,"🎵 베이스 🎵" , "🥁 드럼 🥁" , "🎹 키보드 🎹" , "🎻 바이올린 🎻" , "🎺 트럼펫 🎺"
+        - session은 모집할 세션, currnetSession 밴드에 속한 멤버의 세션을 의미
+    - 장르 타입 "Metal", "New age", "Pop", "Punk", "R&B", "Rock", "Grunge", "Indie Rock", "Jazz", "Shoegaze", "EMO", "Psychedelia", "Dream Pop", "Nu Metal", "J-pop", "Tiwan Indie"
+    - 모집방 상태 타입 "RECRUITING","ACTIVE","ENDED"
+    - 성별 남성 - "MALE", 여성 - "FEMALE", 성별무관 - "OTHER"
+    ---
+    - trackSpotifyIds 예시
+        - 안녕- 5rNyAQzncPBVdEgEG4okNK,
+        - 폭죽과 풍선들- 3P3guXf2RRhjPK0R2UlLZV
+    - artistSpotifyIds 예시
+        - 우효 - 50Zu2bK9y5UAtD0jcqk5VX,
+        - 검정치마- 6WeDO4GynFmK4OxwkBzMW8
+  """)
     @PostMapping(path = "/recruitments", consumes = "multipart/form-data")
     public ResponseEntity<RecruitmentResponse> createBand(
             @RequestPart(value = "data")  @Valid RecruitmentRequest recruit,
@@ -37,7 +50,22 @@ public class BandManagementController {
     }
 
 
-    @Operation(summary = "밴드 모집방 수정하기")
+    @Operation(summary = "밴드 모집방 수정하기",description = """
+    - 세션 타입 "🎤 보컬 🎤" , "🎸 일렉 기타 " , "🪕 어쿠스틱 기타 🪕" ,"🎵 베이스 🎵" , "🥁 드럼 🥁" , "🎹 키보드 🎹" , "🎻 바이올린 🎻" , "🎺 트럼펫 🎺"
+        - session은 모집할 세션, currnetSession 밴드에 속한 멤버의 세션을 의미
+    - 장르 타입 "Metal", "New age", "Pop", "Punk", "R&B", "Rock", "Grunge", "Indie Rock", "Jazz", "Shoegaze", "EMO", "Psychedelia", "Dream Pop", "Nu Metal", "J-pop", "Tiwan Indie"
+    - 모집방 상태 타입 "RECRUITING","ACTIVE","ENDED"
+    - 성별 남성 - "MALE", 여성 - "FEMALE", 성별무관 - "OTHER"
+    ---
+    - trackSpotifyIds 예시
+        - 안녕- 5rNyAQzncPBVdEgEG4okNK
+        - 폭죽과 풍선들- 3P3guXf2RRhjPK0R2UlLZV
+    - artistSpotifyIds 예시
+        - 우효 - 50Zu2bK9y5UAtD0jcqk5VX
+        - 검정치마- 6WeDO4GynFmK4OxwkBzMW8
+    - 주의! List 형태의 정보는 원래 있던 정보와 비교하여 입력되지 않은 정보는 삭제됩니다
+        - A, B, C가 있는 상태에서 A만 입력했다면 수정후 A만 남고 B, C는 삭제
+  """)
     @PatchMapping(path = "/recruitments", consumes = "multipart/form-data")
     public ResponseEntity<RecruitmentResponse> updateBand(
             @RequestPart(value = "data")                RecruitmentUpdateRequest recruit ,
@@ -49,7 +77,9 @@ public class BandManagementController {
         return ResponseEntity.ok(bandManagementService.updateRecruitment(recruit,image, currentMemberId));
     }
 
-    @Operation(summary = "밴드 지원하기")
+    @Operation(summary = "밴드 지원하기",description = """
+    - ** 세션 타입 "🎤 보컬 🎤" , "🎸 일렉 기타 " , "🪕 어쿠스틱 기타 🪕" ,"🎵 베이스 🎵" , "🥁 드럼 🥁" , "🎹 키보드 🎹" , "🎻 바이올린 🎻" , "🎺 트럼펫 🎺"
+  """)
     @PostMapping("/bands/{bandId}/join")
     public ResponseEntity<BandApplicationResponse> createBandApplication(
             @PathVariable Long bandId,
@@ -73,7 +103,9 @@ public class BandManagementController {
         return ResponseEntity.ok(bandManagementService.getApplicationList(bandId, currentMemberId));
     }
 
-    @Operation(summary = "밴드 합격 불합격 처리")
+    @Operation(summary = "밴드 합격 불합격 처리",description = """
+     - Status "PASS", "FAIL"
+    """)
     @PatchMapping("/recruitments/{bandId}")
     public ResponseEntity<ApplicationListResponse> updateApplicantStatus(
             @PathVariable Long bandId,

--- a/src/main/java/com/umc/banddy/domain/band/profile/web/dto/Recruitment/ApplicantUpdateRequest.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/web/dto/Recruitment/ApplicantUpdateRequest.java
@@ -1,8 +1,9 @@
 package com.umc.banddy.domain.band.profile.web.dto.Recruitment;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
 
 import java.util.List;
 import java.util.Map;
@@ -12,6 +13,26 @@ import java.util.Map;
 @Builder
 public class ApplicantUpdateRequest {
 
-    private Map<Long, String> applicantUpdate;
+    @NotEmpty
+    private List<ApplicantUpdateDto> applicantUpdate;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "단일 지원자 업데이트 정보")
+    public static class ApplicantUpdateDto {
+
+        @NotNull
+        @Schema(description = "채팅방 ID", example = "15")
+        private Long roomId;
+
+        @NotNull
+        @Schema(
+                description    = "지원 상태",
+                allowableValues = {"PASS", "FAIL"},
+                example        = "FAIL"
+        )
+        private String status;
+    }
 
 }

--- a/src/main/java/com/umc/banddy/domain/band/profile/web/dto/Recruitment/RecruitmentRequest.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/web/dto/Recruitment/RecruitmentRequest.java
@@ -24,13 +24,34 @@ public class RecruitmentRequest {
     private Boolean autoClose;
     private String description;
 
+
     private List<String> session;
+
     private List<String> genres;
+    @Schema(
+            description = "선택할 아티스트의 Spotify ID 목록",
+            type = "array",
+            allowableValues = {
+                    "7tshn3Sr182m8lyxYKANjA",
+                    "50Zu2bK9y5UAtD0jcqk5VX"
+            },
+            example = "[\"7tshn3Sr182m8lyxYKANjA\", \"50Zu2bK9y5UAtD0jcqk5VX\"]"
+    )
     private List<String> artistSpotifyIds;
+    @Schema(
+            description = "추가할 트랙의 Spotify ID 목록",
+            type = "array",
+            allowableValues = {
+                    "5rNyAQzncPBVdEgEG4okNK",
+                    "3P3guXf2RRhjPK0R2UlLZV"
+            },
+            example = "[\"5rNyAQzncPBVdEgEG4okNK\", \"3P3guXf2RRhjPK0R2UlLZV\"]"
+    )
     private List<String> trackSpotifyIds;
 
     private int ageStart;
     private int ageEnd;
+
     private String gender;
     private String region;
     private String district;

--- a/src/main/java/com/umc/banddy/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/com/umc/banddy/domain/chat/domain/ChatMessage.java
@@ -1,5 +1,6 @@
 package com.umc.banddy.domain.chat.domain;
 
+import com.umc.banddy.domain.chat.domain.enums.Type;
 import com.umc.banddy.domain.member.domain.Member;
 import com.umc.banddy.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -7,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -24,8 +26,11 @@ public class ChatMessage extends BaseEntity {
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
-    // 일단 텍스트만 지원한다고 가정
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @ColumnDefault("'TEXT'")
+    private Type type;
 
     @ManyToOne
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/com/umc/banddy/domain/chat/domain/ChatRoomParticipant.java
+++ b/src/main/java/com/umc/banddy/domain/chat/domain/ChatRoomParticipant.java
@@ -31,6 +31,9 @@ public class ChatRoomParticipant {
     @Column(nullable = false)
     private Status status;
 
+    @Column(nullable = true)
+    private LocalDateTime pinnedAt; //erd에 없음
+
     @Column(nullable = false)
     private LocalDateTime lastReadAt; //erd에 없음
 

--- a/src/main/java/com/umc/banddy/domain/chat/domain/enums/Type.java
+++ b/src/main/java/com/umc/banddy/domain/chat/domain/enums/Type.java
@@ -1,0 +1,5 @@
+package com.umc.banddy.domain.chat.domain.enums;
+
+public enum Type {
+    TEXT, IMAGE, VIDEO, AUDIO, FILE, SYSTEM
+}

--- a/src/main/java/com/umc/banddy/domain/chat/repository/ChatRoomParticipantRepository.java
+++ b/src/main/java/com/umc/banddy/domain/chat/repository/ChatRoomParticipantRepository.java
@@ -11,7 +11,6 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomParticipant, Long> {
 
@@ -58,4 +57,16 @@ public interface ChatRoomParticipantRepository extends JpaRepository<ChatRoomPar
     Optional<ChatRoomParticipant> findByChatRoomAndMember(ChatRoom chatRoom, Member member);
 
     List<ChatRoomParticipant> findAllByChatRoom(ChatRoom chatRoom);
+
+    @Query("""
+        SELECT p
+        FROM ChatRoomParticipant p
+         JOIN FETCH p.chatRoom cr
+         JOIN FETCH p.member m
+        WHERE cr.id = :roomId
+          AND p.status = com.umc.banddy.domain.member.enums.Status.ACTIVE
+        """)
+    List<ChatRoomParticipant> findAllActiveByChatRoomId(
+            @Param("roomId") Long roomId
+    );
 }

--- a/src/main/java/com/umc/banddy/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/umc/banddy/domain/chat/service/ChatMessageService.java
@@ -6,6 +6,7 @@ import com.umc.banddy.domain.chat.domain.ChatRoom;
 import com.umc.banddy.domain.chat.domain.ChatRoomParticipant;
 import com.umc.banddy.domain.chat.domain.enums.Role;
 import com.umc.banddy.domain.chat.domain.enums.RoomType;
+import com.umc.banddy.domain.chat.domain.enums.Type;
 import com.umc.banddy.domain.chat.repository.ChatMessageRepository;
 import com.umc.banddy.domain.chat.repository.ChatRoomParticipantRepository;
 import com.umc.banddy.domain.chat.repository.ChatCustomRepository;
@@ -71,20 +72,25 @@ public class ChatMessageService {
                 .member(member)
                 .chatRoom(chatRoom)
                 .content(member.getNickname() + "님이 채팅방을 나갔습니다.")
+                .type(Type.SYSTEM)
                 .build();
 
         chatMessageRepository.save(chatMessage);
 
         websocketService.topicMessage(
                 chatRoom.getId(),
-                ChatMessageResponse.builder()
-                        .messageId(chatMessage.getId())
-                        .roomId(chatRoom.getId())
-                        .content(chatMessage.getContent())
-                        .senderId(member.getId())
-                        .senderName("System")
-                        .timestamp(chatMessage.getCreatedAt())
-                        .build()
+                toWsMessage(
+                        ChatMessageResponse.builder()
+                                .messageId(chatMessage.getId())
+                                .roomId(chatRoom.getId())
+                                .content(chatMessage.getContent())
+                                .senderId(member.getId())
+                                .senderName("System")
+                                .timestamp(chatMessage.getCreatedAt())
+                                .build()
+                , MessageType.SYSTEM
+                )
+
         );
 
         return ChatSystemResponse.builder()
@@ -121,20 +127,25 @@ public class ChatMessageService {
                 .member(member)
                 .chatRoom(chatRoom)
                 .content(member.getNickname() + "님이 채팅방에 참여하셨습니다.")
+                .type(Type.SYSTEM)
                 .build();
 
         chatMessageRepository.save(chatMessage);;
 
         websocketService.topicMessage(
                 chatRoom.getId(),
-                ChatMessageResponse.builder()
-                        .messageId(chatMessage.getId())
-                        .roomId(chatRoom.getId())
-                        .content(chatMessage.getContent())
-                        .senderId(member.getId())
-                        .senderName("System")
-                        .timestamp(chatMessage.getCreatedAt())
-                        .build()
+                toWsMessage(
+                        ChatMessageResponse.builder()
+                                .messageId(chatMessage.getId())
+                                .roomId(chatRoom.getId())
+                                .content(chatMessage.getContent())
+                                .senderId(member.getId())
+                                .type(Type.SYSTEM)
+                                .senderName("System")
+                                .timestamp(chatMessage.getCreatedAt())
+                                .build()
+                , MessageType.SYSTEM
+                )
         );
 
         return ChatSystemResponse.builder()
@@ -150,13 +161,12 @@ public class ChatMessageService {
                 = chatCustomRepository.findByRoomIdWithCursorAsDto(roomId, cursor, limit);
 
         return CursorChatMessageResponse.builder()
-                .roomId(roomId)
                 .messages(ccm)
                 .hasNext(ccm.size() == limit)
                 .lastMessageId(ccm.isEmpty() ? null : ccm.get(ccm.size() - 1).getMessageId())
                 .build();
-
     }
+
     public void sendChatMessage(Long roomId, Long userId, ChatMessageRequest messageRequest) {
 
         Pair<ChatRoom, Member> pair = chatService.verifedChatRoomAndMember(roomId, userId);
@@ -177,7 +187,6 @@ public class ChatMessageService {
         RoomType roomType = chatRoom.getRoomType();
 
         // 전송 로직 분기
-        // roomType 검증에 대해서는 db 검증을 거칠지, 메세지에서 첨부된 값을 신뢰할지 고민이 필요
         if (roomType.equals(RoomType.GROUP)) {
             // GROUP: 토픽 브로드캐스트
             ChatMessageResponse chatMessageResponse = chatToResponse(chatMessage);
@@ -228,7 +237,6 @@ public class ChatMessageService {
                         .timestamp(chatMessage.getCreatedAt())
                         .build();
                 websocketService.queueUnreadMessage(receiverEmail, toWsMessage(unreadbandResponse, MessageType.UNREAD_MESSAGE));
-
             } else {
                 ChatMessageResponse chatMessageResponse = chatToResponse(chatMessage);
                 websocketService.queuePrivateMessage(receiverEmail, roomId, toWsMessage(chatMessageResponse, MessageType.MESSAGE));

--- a/src/main/java/com/umc/banddy/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/umc/banddy/domain/chat/service/ChatRoomService.java
@@ -25,8 +25,6 @@ import com.umc.banddy.domain.member.repository.MemberRepository;
 import com.umc.banddy.global.infra.S3Uploader;
 import lombok.RequiredArgsConstructor;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -80,10 +78,10 @@ public class ChatRoomService {
                         .lastReadAt(LocalDateTime.now()) // 초기값 설정
                         .build())
                 .toList();
-        List<ChatRoomResponse.RoomMemberinfo> memberinfos = members.stream()
+        List<ChatRoomResponse.RoomMemberInfo> memberinfos = members.stream()
                 .filter(member -> !member.getId().equals(memberId))
                 .map( member -> {
-                    return ChatRoomResponse.RoomMemberinfo.builder()
+                    return ChatRoomResponse.RoomMemberInfo.builder()
                             .memberId(member.getId())
                             .memberName(member.getNickname())
                             .build();
@@ -95,9 +93,8 @@ public class ChatRoomService {
                 .roomName(savedRoom.getName())
                 .roomImageUrl(savedRoom.getImageUrl())
                 .lastMessageTime(LocalDateTime.now()) // 초기값 설정
-                //.pinnedAt(null)
                 .roomtype(savedRoom.getRoomType())
-                .memberinfos(memberinfos)
+                .memberInfos(memberinfos)
                 .build();
     }
 
@@ -161,8 +158,6 @@ public class ChatRoomService {
                 participant.setStatus(Status.ACTIVE);
             }
         });
-
-
         return PrivateChatRoomResponse.builder()
                 .roomId(chatRoom.getId())
                 .build();
@@ -642,6 +637,72 @@ public class ChatRoomService {
                 .managerId(bandManager.getId())
                 .managerName(band.getManager().getNickname())
                 .managerProfileUrl(band.getManager().getProfileImageUrl())
+                .build();
+    }
+
+    @Transactional
+    public PinChatResponse pinChatRoom(Long roomId, Long memberId){
+
+        ChatRoomParticipant participant = participantRepository.findByChatRoom_IdAndMember_IdAndStatus(
+                roomId, memberId, Status.ACTIVE
+        ).orElseThrow(() -> new IllegalArgumentException("해당 채팅방에 참여하지 않은 사용자입니다."));
+
+        if (participant.getPinnedAt() == null) {
+            participant.setPinnedAt(LocalDateTime.now());
+        }
+
+        return PinChatResponse.builder()
+                .roomId(roomId)
+                .pinnedAt(participant.getPinnedAt())
+                .build();
+    }
+
+    @Transactional
+    public PinBandChatRoomResponse pinBandChatRoom(Long bandId, Long memberId){
+
+        Band band = bandRepository.findById(bandId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 밴드입니다. ID: " + bandId));
+        if(!band.getManager().getId().equals(memberId)){
+            throw new IllegalArgumentException("밴드 매니저만 핀할 수 있습니다.");
+        }
+        band.setPinnedAt(LocalDateTime.now());
+
+        return PinBandChatRoomResponse.builder()
+                .bandId(bandId)
+                .pinnedAt(band.getPinnedAt())
+                .build();
+    }
+
+    @Transactional
+    public PinChatResponse unpinChatRoom(Long roomId, Long memberId){
+
+        ChatRoomParticipant participant = participantRepository.findByChatRoom_IdAndMember_IdAndStatus(
+                roomId, memberId, Status.ACTIVE
+        ).orElseThrow(() -> new IllegalArgumentException("해당 채팅방에 참여하지 않은 사용자입니다."));
+
+        if (participant.getPinnedAt() == null) {
+            participant.setPinnedAt(LocalDateTime.now());
+        }
+
+        return PinChatResponse.builder()
+                .roomId(roomId)
+                .pinnedAt(participant.getPinnedAt())
+                .build();
+    }
+
+    @Transactional
+    public PinBandChatRoomResponse unpinBandChatRoom(Long bandId, Long memberId){
+
+        Band band = bandRepository.findById(bandId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 밴드입니다. ID: " + bandId));
+        if(!band.getManager().getId().equals(memberId)){
+            throw new IllegalArgumentException("밴드 매니저만 핀할 수 있습니다.");
+        }
+        band.setPinnedAt(LocalDateTime.now());
+
+        return PinBandChatRoomResponse.builder()
+                .bandId(bandId)
+                .pinnedAt(band.getPinnedAt())
                 .build();
     }
 

--- a/src/main/java/com/umc/banddy/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/umc/banddy/domain/chat/service/ChatRoomService.java
@@ -47,6 +47,8 @@ public class ChatRoomService {
     private final BandRepository bandRepository;
     private final BandChatRepository bandChatRepository;
     private final S3Uploader s3Uploader;
+    private final ChatRoomParticipantCache chatRoomParticipantCache;
+    private final ChatMessageService chatMessageService;
 
 
     // 그룹 채팅방 생성
@@ -220,6 +222,9 @@ public class ChatRoomService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
+        // 3) 내가 매니저로 있는 모든 밴드
+        List<Band> managedBands = bandRepository.findAllActiveByManagerId(memberId);
+
         // 내 참여 정보 불러오기
         List<ChatRoomParticipant> participants
                 = participantRepository.findAllWithRoomParticipantsAndBandChatByMember(member);
@@ -345,24 +350,109 @@ public class ChatRoomService {
                             .build();
                 }).collect(Collectors.toList());
 
-        List<BandManagerRoomInfoDto> adminBandRoomInfos = adminBandRooms.stream()
-                .collect(Collectors.groupingBy(room -> room.getBandChat().getBand().getId()))
-                .values().stream()
-                .map(rooms -> {
 
-                    ChatRoom anyRoom = rooms.get(0);
-                    Band band = anyRoom.getBandChat().getBand();
+        Map<Long, List<ChatRoom>> adminRoomsByBandId = adminBandRooms.stream()
+                .collect(Collectors.groupingBy(r -> r.getBandChat().getBand().getId()));
 
-                    // 각 방에 대한 ChatRoomInfo 생성
-                    List<BandManagerRoomInfoDto.BandChatRoomInfo> chatRoomInfos1 = rooms.stream()
+//        List<BandManagerRoomInfoDto> adminBandRoomInfos = adminBandRooms.stream()
+//                .collect(Collectors.groupingBy(room -> room.getBandChat().getBand().getId()))
+//                .values().stream()
+//                .map(rooms -> {
+//
+//                    ChatRoom anyRoom = rooms.get(0);
+//                    Band band = anyRoom.getBandChat().getBand();
+//
+//                    // 각 방에 대한 ChatRoomInfo 생성
+//                    List<BandManagerRoomInfoDto.BandChatRoomInfo> chatRoomInfos1 = rooms.stream()
+//                            .map(room -> {
+//                                MemberInfo memberInfo = room.getParticipants().stream()
+//                                        .map(ChatRoomParticipant::getMember)
+//                                        .filter(member1 -> !member1.getId().equals(memberId))
+//                                        .map(member1 -> MemberInfo.builder()
+//                                                .memberId(member1.getId())
+//                                                .nickname(member1.getNickname())
+//                                                .profileImageUrl(member1.getProfileImageUrl())
+//                                                .build())
+//                                        .findFirst()
+//                                        .orElse(null);
+//
+//                                return BandManagerRoomInfoDto.BandChatRoomInfo.builder()
+//                                        .roomId(room.getId())
+//                                        .memberInfo(memberInfo)
+//                                        .session(room.getBandChat().getBandSession().getSession().getName())
+//                                        .passFail(room.getBandChat().getPassFail())
+//                                        .lastMessageAt(lastAtMap.get(room.getId()))
+//                                        .UnreadCount(unreadCountMap.get(room.getId()))
+//                                        .build();
+//                            })
+//                            .toList();
+//
+//                    // 1. 전체 UnreadCount 합산
+//                    long totalUnread = chatRoomInfos1.stream()
+//                            .mapToLong(info -> Optional.ofNullable(info.getUnreadCount()).orElse(0L))
+//                            .sum();
+//
+//                    LocalDateTime latest = chatRoomInfos1.stream()
+//                            .map(BandManagerRoomInfoDto.BandChatRoomInfo::getLastMessageAt)
+//                            .filter(Objects::nonNull)
+//                            .max(LocalDateTime::compareTo)
+//                            .orElse(null);
+//
+//                    // 밴드 단위 DTO 조립
+//                    return BandManagerRoomInfoDto.builder()
+//                            .roomType("BAND-MANAGER")
+//                            .bandId(band.getId())
+//                            .bandName(band.getName())
+//                            .bandImageUrl(band.getProfileImageUrl())
+//                            .status(band.getStatus())
+//                            .bandSessionList(
+//                                    band.getBandSessions().stream()
+//                                            .filter(session -> "RECRUITING".equals(session.getSessionStatus()))
+//                                            .map(session -> session.getSession().getName())
+//                                            .distinct()
+//                                            .toList()
+//                            )
+//                            .chatRoomInfo(chatRoomInfos1)
+//                            .lastMessageAt(latest)
+//                            .unreadCount(totalUnread)
+//                            .build();
+//                })
+//                .collect(Collectors.toList());
+        List<BandManagerRoomInfoDto> allAdminBandRoomInfos = managedBands.stream()
+                .map(band -> {
+                    List<ChatRoom> rooms = adminRoomsByBandId.getOrDefault(band.getId(), Collections.emptyList());
+
+                    // 세션 이름 목록(모집 중인 것만)
+                    List<String> recruitingSessions = band.getBandSessions().stream()
+                            .filter(s -> "RECRUITING".equals(s.getSessionStatus()))
+                            .map(s -> s.getSession().getName())
+                            .distinct()
+                            .toList();
+
+                    if (rooms.isEmpty()) {
+                        // 채팅방이 하나도 없을 때
+                        return BandManagerRoomInfoDto.builder()
+                                .roomType("BAND-MANAGER")
+                                .bandId(band.getId())
+                                .bandName(band.getName())
+                                .bandImageUrl(band.getProfileImageUrl())
+                                .status(band.getStatus())
+                                .bandSessionList(recruitingSessions)
+                                .chatRoomInfo(Collections.emptyList())
+                                .unreadCount(0L)
+                                .lastMessageAt(null)
+                                .build();
+                    }
+
+                    List<BandManagerRoomInfoDto.BandChatRoomInfo> chatInfos = rooms.stream()
                             .map(room -> {
                                 MemberInfo memberInfo = room.getParticipants().stream()
                                         .map(ChatRoomParticipant::getMember)
-                                        .filter(member1 -> !member1.getId().equals(memberId))
-                                        .map(member1 -> MemberInfo.builder()
-                                                .memberId(member1.getId())
-                                                .nickname(member1.getNickname())
-                                                .profileImageUrl(member1.getProfileImageUrl())
+                                        .filter(m -> !m.getId().equals(memberId))
+                                        .map(m -> MemberInfo.builder()
+                                                .memberId(m.getId())
+                                                .nickname(m.getNickname())
+                                                .profileImageUrl(m.getProfileImageUrl())
                                                 .build())
                                         .findFirst()
                                         .orElse(null);
@@ -378,142 +468,41 @@ public class ChatRoomService {
                             })
                             .toList();
 
-                    // 1. 전체 UnreadCount 합산
-                    long totalUnread = chatRoomInfos1.stream()
+                    long totalUnread = chatInfos.stream()
                             .mapToLong(info -> Optional.ofNullable(info.getUnreadCount()).orElse(0L))
                             .sum();
-
-                    LocalDateTime latest = chatRoomInfos1.stream()
+                    LocalDateTime latest = chatInfos.stream()
                             .map(BandManagerRoomInfoDto.BandChatRoomInfo::getLastMessageAt)
                             .filter(Objects::nonNull)
                             .max(LocalDateTime::compareTo)
                             .orElse(null);
 
-                    // 밴드 단위 DTO 조립
                     return BandManagerRoomInfoDto.builder()
                             .roomType("BAND-MANAGER")
                             .bandId(band.getId())
                             .bandName(band.getName())
                             .bandImageUrl(band.getProfileImageUrl())
                             .status(band.getStatus())
-                            .bandSessionList(
-                                    band.getBandSessions().stream()
-                                            .filter(session -> "RECRUITING".equals(session.getSessionStatus()))
-                                            .map(session -> session.getSession().getName())
-                                            .distinct()
-                                            .toList()
-                            )
-                            .chatRoomInfo(chatRoomInfos1)
-                            .lastMessageAt(latest)
+                            .bandSessionList(recruitingSessions)
+                            .chatRoomInfo(chatInfos)
                             .unreadCount(totalUnread)
+                            .lastMessageAt(latest)
                             .build();
                 })
-                .collect(Collectors.toList());
+                .toList();
 
 
         List<ChatRoomInfo> combined = Stream.concat(Stream.concat(
                         Stream.concat(
                                 privateChatRoomInfos.stream(),
-                                nonAdminBandRoomInfos.stream()
-                        ),
-                        adminBandRoomInfos.stream()
-                ),
-                        groupChatRoomInfos.stream()
-                )
+                                nonAdminBandRoomInfos.stream()),
+                                allAdminBandRoomInfos.stream()),
+                        groupChatRoomInfos.stream())
                 .sorted(Comparator.comparing(
                         ChatRoomInfo::getLastMessageAt,
                         Comparator.nullsFirst(Comparator.reverseOrder())
                 ))
                 .toList();
-
-//
-//
-//
-//                .map(room ->{
-//                    List<MemberInfo> memberInfos = room.getParticipants().stream()
-//                            .map(p -> MemberInfo.builder()
-//                                    .memberId(p.getMember().getId())
-//                                    .nickname(p.getMember().getNickname())
-//                                    .profileImageUrl(p.getMember().getProfileImageUrl())
-//                                    .build()
-//                            )
-//                            .toList();
-//
-//                    return BandManagerRoomInfoDto.builder()
-//                            .roomId(room.getId())
-//                            .chatName(room.getBandChat().getBand().getName())
-//                            .imageUrl(room.getBandChat().getBand().getProfileImageUrl())
-//                            .memberInfos(memberInfos)
-//                            .unreadCount(unreadCountMap.get(room.getId()))
-//                            .lastMessageAt(lastAtMap.get(room.getId()))
-//                            .build();
-//                }).collect(Collectors.toList());
-//
-//
-//
-//        Map<Boolean, List<ChatRoom>> partitioned = bandRooms.stream()
-//                .collect(Collectors.partitioningBy(
-//                        room -> room.getBandChat().getBand().getManager().equals(member)
-//                ));
-//
-//
-//        Map<Long, List<ChatRoom>> roomsByBand = partitioned.get(true).stream()
-//                .collect(Collectors.groupingBy(
-//                        room -> room.getBandChat().getBand().getId()
-//                ));
-//
-//        List<ManagedRoomInfo> managedRoomInfos = roomsByBand.entrySet().stream()
-//                .map(entry -> {
-//                    Long bandId = entry.getKey();
-//                    List<ChatRoom> rooms = entry.getValue();
-//                    Band band = rooms.get(0).getBandChat().getBand(); // 모두 동일한 밴드
-//
-//                    List<InterviewRoomInfo> roomInfos = rooms.stream()
-//                            .map(room -> {
-//                                ChatRoomParticipant other = room.getParticipants().stream()
-//                                        .filter(p -> !p.getMember().equals(member))
-//                                        .findFirst()
-//                                        .orElseThrow(() -> new IllegalStateException("상대 참가자가 없습니다."));
-//
-//                                return InterviewRoomInfo.builder()
-//                                        .memberId(other.getMember().getId())
-//                                        .profileImageUrl(other.getMember().getProfileImageUrl())
-//                                        .session(room.getBandChat().getBandSession().getSession().toString())      // 세션 정보
-//                                        .lastMessageAt(lastAtMap.get(room.getId()))
-//                                        .unreadCount(unreadCountMap.getOrDefault(room.getId(), 0L))
-//                                        .build();
-//                                    }
-//                            )
-//                            .toList();
-//
-//                    return ManagedRoomInfo.builder()
-//                            .bandId(bandId)
-//                            .bandName(band.getName())
-//                            .profileImageUrl(band.getProfileImageUrl())
-//                            .bandStatus(band.getStatus())
-//                            .recruitingSession(
-//                                    band.getBandSessions().stream()
-//                                            .map(bandSession -> bandSession.getSession().toString())
-//                                            .toList()
-//                            )
-//                            .rooms(roomInfos)
-//                            .build();
-//                })
-//                .toList();
-//
-//        List<AppliedRoomInfo> appliedRoomInfos = partitioned.get(false).stream()
-//                .map(room -> {
-//                    Band band = room.getBandChat().getBand();
-//                    return AppliedRoomInfo.builder()
-//                            .bandId(band.getId())
-//                            .roomId(room.getId())
-//                            .bandName(band.getName())
-//                            .profileImageUrl(band.getProfileImageUrl())
-//                            .unreadCount(unreadCountMap.getOrDefault(room.getId(), 0L))
-//                            .lastMessageAt(lastAtMap.get(room.getId()))
-//                            .build();
-//                })
-//                .toList();
 
         return ChatRoomListResponse.builder()
                 .chatRoomInfos(combined)
@@ -562,10 +551,16 @@ public class ChatRoomService {
     }
 
     @Transactional
-    public ParticipantInfos getChatRoomInfo(ChatRoom chatRoom, Member member){
+    public BasicChatRoomInfo getChatRoomInfo(Long roomId, Long memberId){
 
         List<ChatRoomParticipant> participants
-                = participantRepository.findAllByChatRoom(chatRoom);
+                = participantRepository.findAllActiveByChatRoomId(roomId);
+
+        Member member = participants.stream()
+                .map(ChatRoomParticipant::getMember)
+                .filter(m -> m.getId().equals(memberId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다. ID: " + memberId));
 
         List<ParticipantInfos.Info> infoList = new ArrayList<>();
         for(ChatRoomParticipant participant : participants){
@@ -574,14 +569,21 @@ public class ChatRoomService {
             }
             ParticipantInfos.Info info = ParticipantInfos.Info.builder()
                     .memberId(participant.getMember().getId())
+                    .nickname(participant.getMember().getNickname())
+                    .imageUrl(participant.getMember().getProfileImageUrl())
                     .timestamp(participant.getLastReadAt())
                     .build();
             infoList.add(info);
         }
 
-        return ParticipantInfos.builder()
-                .roomId(chatRoom.getId())
-                .infos(infoList)
+        return BasicChatRoomInfo.builder()
+                .roomId(roomId)
+                .messageList(chatMessageService.getChatMessages(roomId,Long.MAX_VALUE,20))
+                .participantInfos(
+                        ParticipantInfos.builder()
+                                .infos(infoList)
+                                .build()
+                        )
                 .build();
     }
 

--- a/src/main/java/com/umc/banddy/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/umc/banddy/domain/chat/service/ChatRoomService.java
@@ -144,7 +144,7 @@ public class ChatRoomService {
 
 
     // 1:1 채팅 방 조회
-    public PrivateChatRoomResponse getPrivateChatRoom(Long memberId, Long friendId) {
+    public BasicChatRoomInfo getPrivateChatRoom(Long memberId, Long friendId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
         Member friend = memberRepository.findById(friendId)
@@ -160,9 +160,8 @@ public class ChatRoomService {
                 participant.setStatus(Status.ACTIVE);
             }
         });
-        return PrivateChatRoomResponse.builder()
-                .roomId(chatRoom.getId())
-                .build();
+
+        return getChatRoomInfo(chatRoom.getId(), memberId );
     }
     // 개인 채팅방 생성
     public ChatRoom createPrivateChatRoom(
@@ -282,12 +281,20 @@ public class ChatRoomService {
                                     )
                                     .toList();
 
+                    LocalDateTime myPinnedAt = room.getParticipants().stream()
+                            .filter(p -> p.getMember().getId().equals(memberId))
+                            .findFirst()
+                            .map(ChatRoomParticipant::getPinnedAt)
+                            .orElse(null);
+
+
                     return ChatRoomInfoDto.builder()
                             .roomType(String.valueOf(RoomType.GROUP))
                             .roomId(room.getId())
                             .chatName(room.getName())
                             .imageUrl(room.getImageUrl())
                             .memberInfos(memberInfos)
+                            .pinnedAt(myPinnedAt)
                             .unreadCount(unreadCountMap.get(room.getId()))
                             .lastMessageAt(lastAtMap.get(room.getId()))
                             .build();
@@ -307,6 +314,12 @@ public class ChatRoomService {
                             .findFirst()
                             .orElseThrow(() -> new IllegalStateException("내 정보가 없습니다."));
 
+                    LocalDateTime myPinnedAt = room.getParticipants().stream()
+                            .filter(p -> p.getMember().getId().equals(memberId))
+                            .findFirst()
+                            .map(ChatRoomParticipant::getPinnedAt)
+                            .orElse(null);
+
 
                     return PrivateChatRoomInfoDto.builder()
                             .roomType(String.valueOf(RoomType.PRIVATE))
@@ -314,6 +327,7 @@ public class ChatRoomService {
                             .chatName(memberInfo.getNickname())
                             .imageUrl(memberInfo.getProfileImageUrl())
                             .memberInfo(memberInfo)
+                            .pinnedAt(myPinnedAt)
                             .unreadCount(unreadCountMap.get(room.getId()))
                             .lastMessageAt(lastAtMap.get(room.getId()))
                             .build();
@@ -339,12 +353,20 @@ public class ChatRoomService {
                             )
                             .toList();
 
+
+                    LocalDateTime myPinnedAt = room.getParticipants().stream()
+                            .filter(p -> p.getMember().getId().equals(memberId))
+                            .findFirst()
+                            .map(ChatRoomParticipant::getPinnedAt)
+                            .orElse(null);
+
                     return ChatRoomInfoDto.builder()
                             .roomType("BAND-APPLICANT")
                             .roomId(room.getId())
                             .chatName(room.getBandChat().getBand().getName())
                             .imageUrl(room.getBandChat().getBand().getProfileImageUrl())
                             .memberInfos(memberInfos)
+                            .pinnedAt(myPinnedAt)
                             .unreadCount(unreadCountMap.get(room.getId()))
                             .lastMessageAt(lastAtMap.get(room.getId()))
                             .build();
@@ -429,6 +451,7 @@ public class ChatRoomService {
                             .distinct()
                             .toList();
 
+
                     if (rooms.isEmpty()) {
                         // 채팅방이 하나도 없을 때
                         return BandManagerRoomInfoDto.builder()
@@ -439,6 +462,7 @@ public class ChatRoomService {
                                 .status(band.getStatus())
                                 .bandSessionList(recruitingSessions)
                                 .chatRoomInfo(Collections.emptyList())
+                                .pinnedAt(band.getPinnedAt())
                                 .unreadCount(0L)
                                 .lastMessageAt(null)
                                 .build();
@@ -457,9 +481,16 @@ public class ChatRoomService {
                                         .findFirst()
                                         .orElse(null);
 
+                                LocalDateTime myPinnedAt = room.getParticipants().stream()
+                                        .filter(p -> p.getMember().getId().equals(memberId))
+                                        .findFirst()
+                                        .map(ChatRoomParticipant::getPinnedAt)
+                                        .orElse(null);
+
                                 return BandManagerRoomInfoDto.BandChatRoomInfo.builder()
                                         .roomId(room.getId())
                                         .memberInfo(memberInfo)
+                                        .pinnedAt( myPinnedAt)
                                         .session(room.getBandChat().getBandSession().getSession().getName())
                                         .passFail(room.getBandChat().getPassFail())
                                         .lastMessageAt(lastAtMap.get(room.getId()))
@@ -477,6 +508,7 @@ public class ChatRoomService {
                             .max(LocalDateTime::compareTo)
                             .orElse(null);
 
+
                     return BandManagerRoomInfoDto.builder()
                             .roomType("BAND-MANAGER")
                             .bandId(band.getId())
@@ -485,6 +517,7 @@ public class ChatRoomService {
                             .status(band.getStatus())
                             .bandSessionList(recruitingSessions)
                             .chatRoomInfo(chatInfos)
+                            .pinnedAt(band.getPinnedAt())
                             .unreadCount(totalUnread)
                             .lastMessageAt(latest)
                             .build();
@@ -498,14 +531,24 @@ public class ChatRoomService {
                                 nonAdminBandRoomInfos.stream()),
                                 allAdminBandRoomInfos.stream()),
                         groupChatRoomInfos.stream())
+                .toList();
+
+        List<ChatRoomInfo> pinnedRooms = combined.stream()
+                .filter(info -> info.getPinnedAt() != null)
+                .sorted(Comparator.comparing(ChatRoomInfo::getPinnedAt).reversed())
+                .toList();
+        List<ChatRoomInfo> unpinnedRooms = combined.stream()
+                .filter(info -> info.getPinnedAt() == null)
                 .sorted(Comparator.comparing(
                         ChatRoomInfo::getLastMessageAt,
                         Comparator.nullsFirst(Comparator.reverseOrder())
                 ))
                 .toList();
 
+        List<ChatRoomInfo> sorted = Stream.concat(pinnedRooms.stream(), unpinnedRooms.stream())
+                .toList();
         return ChatRoomListResponse.builder()
-                .chatRoomInfos(combined)
+                .chatRoomInfos(sorted)
                 .build();
 
     }
@@ -566,6 +609,7 @@ public class ChatRoomService {
         for(ChatRoomParticipant participant : participants){
             if(participant.getMember().getId().equals(member.getId())){
                 participant.setLastReadAt(LocalDateTime.now());
+                continue;
             }
             ParticipantInfos.Info info = ParticipantInfos.Info.builder()
                     .memberId(participant.getMember().getId())
@@ -664,7 +708,7 @@ public class ChatRoomService {
 
         Band band = bandRepository.findById(bandId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 밴드입니다. ID: " + bandId));
-        if(!band.getManager().getId().equals(memberId)){
+        if(!memberId.equals(band.getManager().getId())){
             throw new IllegalArgumentException("밴드 매니저만 핀할 수 있습니다.");
         }
         band.setPinnedAt(LocalDateTime.now());
@@ -682,8 +726,8 @@ public class ChatRoomService {
                 roomId, memberId, Status.ACTIVE
         ).orElseThrow(() -> new IllegalArgumentException("해당 채팅방에 참여하지 않은 사용자입니다."));
 
-        if (participant.getPinnedAt() == null) {
-            participant.setPinnedAt(LocalDateTime.now());
+        if (participant.getPinnedAt() != null) {
+            participant.setPinnedAt(null);
         }
 
         return PinChatResponse.builder()
@@ -700,7 +744,7 @@ public class ChatRoomService {
         if(!band.getManager().getId().equals(memberId)){
             throw new IllegalArgumentException("밴드 매니저만 핀할 수 있습니다.");
         }
-        band.setPinnedAt(LocalDateTime.now());
+        band.setPinnedAt(null);
 
         return PinBandChatRoomResponse.builder()
                 .bandId(bandId)

--- a/src/main/java/com/umc/banddy/domain/chat/web/controller/ChatContoller.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/controller/ChatContoller.java
@@ -30,7 +30,7 @@ public class ChatContoller {
     private final JwtTokenUtil jwtTokenUtil;
     private final ChatMessageService chatMessageService;
 
-    @Operation(summary = " 단체 채팅방 생성", description = "단체 채팅방 생성 api")
+    @Operation(summary = " 단체 채팅방 생성", description = "단체 채팅방 생성 api, 본인을 제외한 참여자 Id 입력")
     @PostMapping(path = "/rooms", consumes = "multipart/form-data")
     public ResponseEntity<ChatRoomResponse> createChatRoom(
             @RequestPart(value = "data") @Valid  ChatRoomRequest chatRoomRequest,
@@ -55,7 +55,7 @@ public class ChatContoller {
 
     @Operation(summary = "개인 채팅방 생성, 입장", description = "친구페이지에서 개인 채팅방 입장, 채팅방이 없는 경우도 자동 생성 api")
     @PostMapping("/rooms/friends")
-    public ResponseEntity<PrivateChatRoomResponse> createPrivateChatRooms(
+    public ResponseEntity<BasicChatRoomInfo> createPrivateChatRooms(
             @RequestBody @Valid PrivateChatRoomRequest privateChatRoomRequest,
             HttpServletRequest request
     ) {
@@ -114,15 +114,15 @@ public class ChatContoller {
         return ResponseEntity.ok(chatRoomService.getMyChatRooms(currentMemberId));
     }
 
-    @Operation(summary = "친구 채팅방 목록 조회")
-    @GetMapping("/friends")
-    public ResponseEntity <FriendsChatRoomResponse> getFriendsChatRooms(
-            HttpServletRequest request
-    ){
-        String token = JwtTokenUtil.extractToken(request);
-        Long currentMemberId = jwtTokenUtil.getMemberIdFromToken(token);
-        return ResponseEntity.ok(chatRoomService.getFriendsChatRoom(currentMemberId));
-    }
+//    @Operation(summary = "친구 채팅방 목록 조회")
+//    @GetMapping("/friends")
+//    public ResponseEntity <FriendsChatRoomResponse> getFriendsChatRooms(
+//            HttpServletRequest request
+//    ){
+//        String token = JwtTokenUtil.extractToken(request);
+//        Long currentMemberId = jwtTokenUtil.getMemberIdFromToken(token);
+//        return ResponseEntity.ok(chatRoomService.getFriendsChatRoom(currentMemberId));
+//    }
 
     @Operation(summary = "채팅방 입장시 필요 정보 불러오기")
     @GetMapping("/rooms/{roomId}")
@@ -147,12 +147,12 @@ public class ChatContoller {
         if( bandId == null && chatId != null) {
            return ResponseEntity.ok(chatRoomService.pinChatRoom( chatId, currentMemberId));
         }else if(bandId != null && chatId == null) {
-            return ResponseEntity.ok(chatRoomService.pinBandChatRoom(currentMemberId, bandId));
+            return ResponseEntity.ok(chatRoomService.pinBandChatRoom(bandId,currentMemberId));
         }else{
             return ResponseEntity.badRequest().body("bandId or chatId must be provided");
         }
     }
-    @Operation(summary = "채팅방 고정 해제")
+    @Operation(summary = "채팅방 고정 해제",description = " bandId와 chatId 둘 중 하나만 입력해주세요")
     @PatchMapping("/rooms/unpin")
     public ResponseEntity <?> unpinChatRoom(
             @RequestParam(required = false) Long bandId,
@@ -164,8 +164,11 @@ public class ChatContoller {
         if( bandId == null && chatId != null) {
             return ResponseEntity.ok(chatRoomService.unpinChatRoom( chatId, currentMemberId));
         }else if(bandId != null && chatId == null) {
-            return ResponseEntity.ok(chatRoomService.unpinBandChatRoom(currentMemberId, bandId));
-        }else{
+            return ResponseEntity.ok(chatRoomService.unpinBandChatRoom(bandId,currentMemberId));
+        }else if(bandId != null && chatId != null) {
+            return ResponseEntity.badRequest().body("하나만 입력해주세요");
+        }
+        else{
             return ResponseEntity.badRequest().body("bandId or chatId must be provided");
         }
     }

--- a/src/main/java/com/umc/banddy/domain/chat/web/controller/ChatContoller.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/controller/ChatContoller.java
@@ -53,7 +53,7 @@ public class ChatContoller {
         return ResponseEntity.ok(chatRoomService.updateGroupChatRoom(currentMemberId, image, updateGroupChatRequest));
     }
 
-    @Operation(summary = "개인 채팅방 조회")
+    @Operation(summary = "개인 채팅방 생성, 입장", description = "친구페이지에서 개인 채팅방 입장, 채팅방이 없는 경우도 자동 생성 api")
     @PostMapping("/rooms/friends")
     public ResponseEntity<PrivateChatRoomResponse> createPrivateChatRooms(
             @RequestBody @Valid PrivateChatRoomRequest privateChatRoomRequest,
@@ -132,6 +132,46 @@ public class ChatContoller {
         Pair<ChatRoom,Member> pair = chatService.verifedChatRoomAndMember(roomId, currentMemberId);
         return ResponseEntity.ok(chatRoomService.getChatRoomInfo(pair.getLeft(),pair.getRight()));
     }
+
+    @Operation(summary = "채팅방 고정하기")
+    @PatchMapping("/rooms/pin")
+    public ResponseEntity <?> pinChatRoom(
+            @RequestParam(required = false) Long bandId,
+            @RequestParam(required = false) Long chatId,
+            HttpServletRequest request
+    ) {
+        String token = JwtTokenUtil.extractToken(request);
+        Long currentMemberId = jwtTokenUtil.getMemberIdFromToken(token);
+        if( bandId == null && chatId != null) {
+           return ResponseEntity.ok(chatRoomService.pinChatRoom( chatId, currentMemberId));
+        }else if(bandId != null && chatId == null) {
+            return ResponseEntity.ok(chatRoomService.pinBandChatRoom(currentMemberId, bandId));
+        }else{
+            return ResponseEntity.badRequest().body("bandId or chatId must be provided");
+        }
+    }
+    @Operation(summary = "채팅방 고정 해제")
+    @PatchMapping("/rooms/unpin")
+    public ResponseEntity <?> unpinChatRoom(
+            @RequestParam(required = false) Long bandId,
+            @RequestParam(required = false) Long chatId,
+            HttpServletRequest request
+    ) {
+        String token = JwtTokenUtil.extractToken(request);
+        Long currentMemberId = jwtTokenUtil.getMemberIdFromToken(token);
+        if( bandId == null && chatId != null) {
+            return ResponseEntity.ok(chatRoomService.unpinChatRoom( chatId, currentMemberId));
+        }else if(bandId != null && chatId == null) {
+            return ResponseEntity.ok(chatRoomService.unpinBandChatRoom(currentMemberId, bandId));
+        }else{
+            return ResponseEntity.badRequest().body("bandId or chatId must be provided");
+        }
+    }
+
+
+
+
+
 
 //    @Operation(summary = "밴드 지원하기")
 //    @PostMapping("/bands/{bandId}/join")

--- a/src/main/java/com/umc/banddy/domain/chat/web/controller/ChatContoller.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/controller/ChatContoller.java
@@ -92,13 +92,16 @@ public class ChatContoller {
     @GetMapping("/rooms/{roomId}/messages")
     public ResponseEntity<CursorChatMessageResponse> getChatMessages(
             @PathVariable Long roomId,
-            @RequestParam(required = false, defaultValue = "0") Long cursor,
+            @RequestParam(required = false) Long cursor,
             @RequestParam(required = false, defaultValue = "20") Integer limit,
             HttpServletRequest request
     ) {
+        // 초기 요청인 경우(Long.MAX_VALUE = 9_223_372_036_854_775_807)
+        long effectiveCursor = (cursor == null) ? Long.MAX_VALUE : cursor;
+
         String token = JwtTokenUtil.extractToken(request);
         Long currentMemberId = jwtTokenUtil.getMemberIdFromToken(token);
-        return ResponseEntity.ok(chatMessageService.getChatMessages(roomId, cursor, limit));
+        return ResponseEntity.ok(chatMessageService.getChatMessages(roomId, effectiveCursor, limit));
     }
 
     @Operation(summary = "채팅방 목록 조회")
@@ -121,16 +124,15 @@ public class ChatContoller {
         return ResponseEntity.ok(chatRoomService.getFriendsChatRoom(currentMemberId));
     }
 
-    @Operation(summary = "채팅방 참가자 정보 불러오기")
+    @Operation(summary = "채팅방 입장시 필요 정보 불러오기")
     @GetMapping("/rooms/{roomId}")
-    public ResponseEntity <ParticipantInfos> getChatRoomInfo(
+    public ResponseEntity <BasicChatRoomInfo> getChatRoomInfo(
             @PathVariable Long roomId,
             HttpServletRequest request
     ){
         String token = JwtTokenUtil.extractToken(request);
         Long currentMemberId = jwtTokenUtil.getMemberIdFromToken(token);
-        Pair<ChatRoom,Member> pair = chatService.verifedChatRoomAndMember(roomId, currentMemberId);
-        return ResponseEntity.ok(chatRoomService.getChatRoomInfo(pair.getLeft(),pair.getRight()));
+        return ResponseEntity.ok(chatRoomService.getChatRoomInfo(roomId, currentMemberId));
     }
 
     @Operation(summary = "채팅방 고정하기")

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/MessageType.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/MessageType.java
@@ -2,8 +2,6 @@ package com.umc.banddy.domain.chat.web.dto;
 
 public enum MessageType {
     MESSAGE, // 일반 메시지
-    JOIN, // 입장 메시지
-    LEAVE, // 퇴장 메시지
     SYSTEM, // 시스템 메시지
     MARk_AS_READ, // 읽음 표시 메시지
     MARK_AS_UNREAD, // 읽지 않음 표시 메시지

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/BasicChatRoomInfo.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/BasicChatRoomInfo.java
@@ -1,0 +1,17 @@
+package com.umc.banddy.domain.chat.web.dto.chatroom;
+
+import com.umc.banddy.domain.chat.web.dto.message.CursorChatMessageResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class BasicChatRoomInfo {
+    private Long roomId;
+    private CursorChatMessageResponse messageList;
+    private ParticipantInfos participantInfos;
+}

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/ParticipantInfos.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/ParticipantInfos.java
@@ -12,10 +12,7 @@ import java.util.List;
 @Builder
 public class ParticipantInfos {
 
-    private Long roomId;
-
     private List<Info> infos;
-
 
     @Getter
     @AllArgsConstructor
@@ -23,7 +20,8 @@ public class ParticipantInfos {
     public static class Info{
 
         private Long memberId;
+        private String nickname;
+        private String imageUrl;
         private LocalDateTime timestamp;
     }
-
 }

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/PinBandChatRoomResponse.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/PinBandChatRoomResponse.java
@@ -1,0 +1,16 @@
+package com.umc.banddy.domain.chat.web.dto.chatroom;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class PinBandChatRoomResponse {
+
+    private Long bandId;
+    private LocalDateTime pinnedAt;
+}

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/PinChatResponse.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/PinChatResponse.java
@@ -1,0 +1,16 @@
+package com.umc.banddy.domain.chat.web.dto.chatroom;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class PinChatResponse {
+
+    private Long roomId;
+    private LocalDateTime pinnedAt;
+}

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/creation/BandJoinRequest.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/creation/BandJoinRequest.java
@@ -1,5 +1,7 @@
 package com.umc.banddy.domain.chat.web.dto.chatroom.creation;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,5 +11,19 @@ import lombok.Getter;
 @Builder
 public class BandJoinRequest {
 
+
+    @Schema(
+            description = "지원 세션, 중복 안됨",
+            type = "string",
+            allowableValues = {"🎤 보컬 🎤",
+            "🎸 일렉 기타 🎸",
+            "🪕 어쿠스틱 기타 🪕",
+            "🎵 베이스 🎵",
+            "🥁 드럼 🥁",
+            "🎹 키보드 🎹",
+            "🎻 바이올린 🎻",
+            "🎺 트럼펫 🎺"},
+            example = "🎸 일렉 기타 🎸"
+    )
     private String session;
 }

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/creation/ChatRoomRequest.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/creation/ChatRoomRequest.java
@@ -12,12 +12,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class ChatRoomRequest {
-//    @Schema(
-//            description = "업데이트할 프로필 이미지(선택)",
-//            type        = "string",
-//            format      = "binary"
-//    )
-//    private MultipartFile image;
+
     private List<Long> memberIds;
     private String roomName;
 }

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/creation/ChatRoomResponse.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/creation/ChatRoomResponse.java
@@ -17,13 +17,12 @@ public class ChatRoomResponse {
     private String roomName;
     private String roomImageUrl;
     private LocalDateTime lastMessageTime;
-    //private LocalDateTime pinnedAt;
     private RoomType roomtype;
-    private List<RoomMemberinfo> memberinfos;
+    private List<RoomMemberInfo> memberInfos;
 
     @Getter
     @Builder
-    public static class RoomMemberinfo {
+    public static class RoomMemberInfo {
         private Long memberId;
         private String memberName;
     }

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/roomlist/BandManagerRoomInfoDto.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/roomlist/BandManagerRoomInfoDto.java
@@ -37,6 +37,7 @@ public class BandManagerRoomInfoDto extends ChatRoomInfo {
         private String session;
         private PassFail passFail;
         private LocalDateTime lastMessageAt;
+        private LocalDateTime pinnedAt;
         private Long UnreadCount;
     }
 }

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/roomlist/ChatRoomInfo.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/chatroom/roomlist/ChatRoomInfo.java
@@ -9,9 +9,12 @@ import java.time.LocalDateTime;
 @SuperBuilder
 public abstract class ChatRoomInfo {
 
+
     private String roomType;
 
     private Long unreadCount;
+
+    private LocalDateTime pinnedAt;
 
     private LocalDateTime lastMessageAt;
 }

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/message/ChatMessageResponse.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/message/ChatMessageResponse.java
@@ -1,5 +1,6 @@
 package com.umc.banddy.domain.chat.web.dto.message;
 
+import com.umc.banddy.domain.chat.domain.enums.Type;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +16,7 @@ public class ChatMessageResponse {
     private Long senderId;
     private String senderName;
     private String content; // 메세지 내용, 나중에는 몽고 DB로 다양한 타입 받을 예정
-    //private String type; // 메시지 타입 (예: TEXT, IMAGE 등)
+    private Type type; // 메시지 타입 (예: TEXT, IMAGE 등)
     private Long roomId; // 메시지가 속한 채팅방 ID
     private LocalDateTime timestamp; // 메시지 전송 시간
 }

--- a/src/main/java/com/umc/banddy/domain/chat/web/dto/message/CursorChatMessageResponse.java
+++ b/src/main/java/com/umc/banddy/domain/chat/web/dto/message/CursorChatMessageResponse.java
@@ -11,7 +11,6 @@ import java.util.List;
 @Builder
 public class CursorChatMessageResponse {
 
-    private Long roomId;
     private List<CursorChatMessage> messages;
     private boolean hasNext;
     private Long lastMessageId;


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- 


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- pin / unpin api 추가
- 참가자 테이블에 pinnedAt 필드 추가
- 채팅방 조회시 아직 밴드 채팅이 생성 되지 않은 band-manager 방은 조회가 되지 않던 문제 수정
- pin 기능 추가에 따른 채팅방 목록 조회 화면 로직 수정
- 채팅 참가 및 퇴장시 메세지 저장, 발송시 system 타입으로 명시
- 채팅방 방 입장시 필요한 정보 및 무한 스크롤 병합
- 밴드 생성, 수정에 필요한 enum 및 값들 swagger에 기록
- 밴드 합격 , 불합격 api에서 request 형태 수정
-  무한 스크롤시 초기값 Long.MAX_VALUE 설정
- 

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- 
