### PR TITLE
Refactor: 곡, 아티스트 spotifyIds 받아 저장하고 반환하는 메서드 추가

### DIFF
--- a/src/main/java/com/umc/banddy/domain/music/artist/service/ArtistService.java
+++ b/src/main/java/com/umc/banddy/domain/music/artist/service/ArtistService.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import se.michaelthelin.spotify.SpotifyApi;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -168,6 +169,21 @@ public class ArtistService {
         var memberArtistOpt = memberArtistRepository.findByMemberAndArtist(member, artist);
         Long memberArtistId = memberArtistOpt.map(MemberArtist::getId).orElse(null);
         return ArtistConverter.toArtistResponseDto(artist, memberArtistId);
+    }
+
+    /**
+     * 여러 아티스트의 Spotify ID를 받아 모두 저장하고 반환
+     */
+    @Transactional
+    public List<Artist> saveArtistsBySpotifyIds(List<String> spotifyIds) {
+        List<Artist> result = new ArrayList<>();
+        for (String id : spotifyIds) {
+            if (id == null || id.trim().isEmpty()) continue;
+            Artist artist = artistRepository.findBySpotifyId(id.trim())
+                    .orElseGet(() -> fetchAndSaveArtistFromSpotify(id.trim()));
+            result.add(artist);
+        }
+        return result;
     }
 
 }

--- a/src/main/java/com/umc/banddy/domain/music/track/service/TrackService.java
+++ b/src/main/java/com/umc/banddy/domain/music/track/service/TrackService.java
@@ -25,7 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import se.michaelthelin.spotify.SpotifyApi;
 
 
-
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -226,6 +226,19 @@ public class TrackService {
                 .collect(Collectors.toList());
     }
 
-
+    /**
+     * 여러 곡의 Spotify ID를 받아 모두 저장하고 반환
+     */
+    @Transactional
+    public List<Track> saveTracksBySpotifyIds(List<String> spotifyIds) {
+        List<Track> result = new ArrayList<>();
+        for (String id : spotifyIds) {
+            if (id == null || id.trim().isEmpty()) continue;
+            Track track = trackRepository.findBySpotifyId(id.trim())
+                    .orElseGet(() -> fetchAndSaveTrackFromSpotify(id.trim()));
+            result.add(track);
+        }
+        return result;
+    }
 
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- 


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- 밴드 생성, 수정할 때 사용하기 위해 곡, 아티스트 spotifyIds 받아 저장하고 반환하는 메서드 추가

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- 
