### PR TITLE
Fix: redis host 이름 redis로 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,7 +40,7 @@ spring:
     # 레디스
   data:
     redis:
-      host: localhost
+      host: redis
       port: 6379
 
     cache:


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- 


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
- redis를 도커 컨테이너로 실행하기 위해 application.yml redis의 host 이름을 localhost -> redis로 변경

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- 
