### PR TITLE
fix:밴드 정보 조회시 저장한 음성 정보 응답하도록 수정

### DIFF
--- a/src/main/java/com/umc/banddy/domain/band/bookmark/converter/BandBookmarkConverter.java
+++ b/src/main/java/com/umc/banddy/domain/band/bookmark/converter/BandBookmarkConverter.java
@@ -20,6 +20,7 @@ public class BandBookmarkConverter {
                 .isSoundOn(bookmark.isSoundOn())
                 .memberSummary(memberSummary)
                 .memberCount(totalCount)
+                .soundUrl(bookmark.getBand().getFileUrl())
                 .build();
     }
 

--- a/src/main/java/com/umc/banddy/domain/band/bookmark/web/dto/BandBookmarkResponse.java
+++ b/src/main/java/com/umc/banddy/domain/band/bookmark/web/dto/BandBookmarkResponse.java
@@ -16,4 +16,5 @@ public class BandBookmarkResponse {
     private boolean isSoundOn;
     private String memberSummary;
     private int memberCount;
+    private String soundUrl;
 }

--- a/src/main/java/com/umc/banddy/domain/band/profile/service/BandManagementService.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/service/BandManagementService.java
@@ -662,9 +662,6 @@ public class BandManagementService {
             }
         });
 
-        //
-
-
 
         return getApplicationList(bandId, memberId);
     }
@@ -721,8 +718,8 @@ public class BandManagementService {
         Map<String, String> snsLinkMap = snsLinks.stream()
                 .collect(Collectors.toMap(BandSns::getPlatform, BandSns::getSnsLink));
 
-        BandInquiryResponse.representativeSong repSong = Optional.ofNullable(band.getRepresentativeTrack())
-                .map(track -> BandInquiryResponse.representativeSong.builder()
+        BandInquiryResponse.RepresentativeSong repSong = Optional.ofNullable(band.getRepresentativeTrack())
+                .map(track -> BandInquiryResponse.RepresentativeSong.builder()
                         .spotifyId(track.getSpotifyId())
                         .artist(track.getArtist())
                         .trackTitle(track.getTitle())
@@ -732,6 +729,10 @@ public class BandManagementService {
 
         return BandInquiryResponse.builder()
                 .representativeSong(repSong)
+                .representativeSongFile(BandInquiryResponse.RepresentativeSongFile.builder()
+                        .originalFilename(band.getOriginalFilename())
+                        .fileUrl(band.getFileUrl())
+                        .build())
                 .profileImageUrl(band.getProfileImageUrl())
                 .status(band.getStatus())
                 .name(band.getName())

--- a/src/main/java/com/umc/banddy/domain/band/profile/web/dto/Recruitment/BandInquiryResponse.java
+++ b/src/main/java/com/umc/banddy/domain/band/profile/web/dto/Recruitment/BandInquiryResponse.java
@@ -22,7 +22,9 @@ public class BandInquiryResponse {
 
     private String profileImageUrl;
 
-    private representativeSong representativeSong;
+    private RepresentativeSong representativeSong;
+
+    private RepresentativeSongFile representativeSongFile;
 
     private String name;
 
@@ -64,7 +66,16 @@ public class BandInquiryResponse {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class representativeSong{
+    public static class RepresentativeSongFile{
+        private String originalFilename;
+        private String fileUrl;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RepresentativeSong{
         private String spotifyId;
         private String artist;
         private String trackTitle;
@@ -87,11 +98,6 @@ public class BandInquiryResponse {
         private String title;
         private String imageUrl;
     }
-
-
-
-
-
 
 
 }

--- a/src/main/java/com/umc/banddy/global/infra/S3PresignedUrl.java
+++ b/src/main/java/com/umc/banddy/global/infra/S3PresignedUrl.java
@@ -24,7 +24,7 @@ public class S3PresignedUrl {
     private String bucket;
 
     /**
-     * Presigned PUT URL 발급 (업로드 용, 퍼블릭 접근 가능)
+     * Presigned PUT URL 발급 (업로드 용)
      *
      * @param keyPrefix        저장 경로 prefix (예: audios/123/2025/08/19)
      * @param originalFilename 원본 파일명 (확장자 추출용)
@@ -42,7 +42,7 @@ public class S3PresignedUrl {
                 throw new IllegalArgumentException("keyPrefix가 비어 있습니다.");
             }
 
-            // 확장자 추출
+            // 확장자 추출 (없으면 "")
             String ext = "";
             int dot = originalFilename.lastIndexOf(".");
             if (dot != -1 && dot < originalFilename.length() - 1) {
@@ -59,12 +59,11 @@ public class S3PresignedUrl {
             GeneratePresignedUrlRequest req = new GeneratePresignedUrlRequest(bucket, objectKey)
                     .withMethod(HttpMethod.PUT)
                     .withExpiration(expiration);
-
             req.addRequestParameter("Content-Type", contentType);
 
             URL uploadUrl = amazonS3.generatePresignedUrl(req);
 
-            // 업로드 후 접근 가능한 퍼블릭 URL
+            // 공개 URL (fileUrl)
             String fileUrl = String.format("https://%s.s3.ap-northeast-2.amazonaws.com/%s", bucket, objectKey);
 
             return new PresignResult(
@@ -83,8 +82,8 @@ public class S3PresignedUrl {
     }
 
     public record PresignResult(
-            String uploadUrl,
-            String fileUrl,
+            String uploadUrl,      // 업로드용 presigned URL
+            String fileUrl,        // 업로드 후 접근 가능한 공개 URL
             String originalFilename,
             String contentType,
             long expiresAt


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 연관된 이슈 번호를 작성해주세요. -->
- #이슈번호


## 📌 PR 내용
<!-- PR 내용을 설명해주세요. -->
-  밴드 정보 조회시 저장한 음성 url 같이 응답하도록 수정
-  join 화면에서 음성 url 같이 응답하도록 수정

## 🗣️ 팀원에게 공유할 내용
<!-- 팀원들이 알아야 할 내용이나 논의해야 할 부분이 있다면 작성해주세요. -->
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분이 있으면 작성해주세요. -->
- 
